### PR TITLE
Add dumpso/fixso commands for native .so memory dumping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PACKAGE = main
 BPF_FILE = bpf.c
 
 # TYPE = -type trace_event -type trace_config
-TYPE = -type config_t -type dex_event_data_t -type dex_chunk_event_t -type method_event_data_t -type dex_read_failure_t
+TYPE = -type config_t -type dex_event_data_t -type dex_chunk_event_t -type method_event_data_t -type dex_read_failure_t -type jni_method_event_t
 
 HEADERS = headers
 VMLINUX_HEADERS = vmlinux/$(TARGET)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **被动转储**: 非侵入式内存分析
 - **实时追踪**: 可选的方法执行监控
 - **自动修复**: 内置 DEX 文件修复功能
+- **Native 层转储**: 支持从进程内存中转储 .so 动态库(含自映射的匿名 ELF 镜像),并自动修复段头以便静态分析
 - **高性能**: 使用无锁缓存和优化的字符串处理
 - **简化操作**: 智能默认配置，一条命令完成转储和修复
 
@@ -41,6 +42,8 @@ eBPFDexDumper [命令] [选项]
 **可用命令:**
 - `dump` - 启动基于 eBPF 的 DEX 转储器
 - `fix` - 修复目录中的转储 DEX 文件
+- `dumpso` - 从运行中进程的内存转储 native .so 动态库
+- `fixso` - 修复目录中转储的 .so 文件
 
 ### `dump` 命令
 将探针附加到 libart 并流式传输 DEX/方法事件。您必须提供 `--uid` 或 `--name` 之一来过滤目标应用。
@@ -99,6 +102,46 @@ eBPFDexDumper [命令] [选项]
 ./eBPFDexDumper fix -d /data/local/tmp/out
 ```
 ![alt text](img/image-fix.png)
+
+### `dumpso` 命令
+从目标进程内存中转储 native .so 动态库。与 `dump` 不同,这个功能不依赖 eBPF/uprobe,而是直接解析目标进程的 `/proc/<pid>/maps`,把同一个库分散映射的多个内存段(r--/r-x/rw-)合并还原成完整镜像,再通过 `process_vm_readv` 读出。默认还会扫描没有文件路径的匿名内存区域,只要其起始页是 ELF 魔数(`\x7fELF`),就当作自映射/自解密的库一并转储——这类不走标准动态链接器加载路径的场景,常见于对 native 层做了加固/VMP 的应用。您必须提供 `--uid` 或 `--name` 之一来选择目标进程。
+
+**选项:**
+- `--uid, -u <uid>` - 按 UID 过滤(`--name` 的替代方案)
+- `--name, -n <package>` - Android 包名以派生 UID(`--uid` 的替代方案)
+- `--lib, -l <substr>` - 只转储路径包含此子串的库(默认转储所有应用相关的 .so)
+- `--out, -o, --output <dir>` - 设备上的输出目录(默认值:`/data/local/tmp/so_out`)
+- `--anon, -a` - 同时扫描自映射的匿名 ELF 镜像(默认值:**true**)
+- `--auto-fix, -f` - 转储完成后自动修复 .so 文件(默认值:**true**)
+- `--no-anon` - 禁用匿名 ELF 区域扫描
+- `--no-auto-fix` - 禁用自动修复
+
+**示例:**
+```bash
+# 最简用法 - 按包名转储该应用所有进程映射的 .so,自动修复
+./eBPFDexDumper dumpso -n com.example.app
+
+# 只转储某个特定库
+./eBPFDexDumper dumpso -n com.example.app -l libnative-lib.so
+
+# 关闭匿名 ELF 扫描，只处理正常动态链接的库
+./eBPFDexDumper dumpso -n com.example.app --no-anon
+```
+
+**输出文件:**
+- **原始 .so**: `so_<pid>_<base>_<size>_<name>.so` 保存在输出目录下
+- **修复后的 .so**: `fix/so_<pid>_<base>_<size>_<name>_fix.so`,重写了 `PT_LOAD` 段的 `p_offset`/`p_filesz` 并清空过期的节头信息,便于 IDA/Ghidra 等工具直接加载分析
+
+### `fixso` 命令
+扫描目录中转储的 .so 文件并修复段头。
+
+**选项:**
+- `--dir, -d <dir>` - 包含转储 .so 文件的目录(必需)
+
+**示例:**
+```bash
+./eBPFDexDumper fixso -d /data/local/tmp/so_out
+```
 
 ## 安装与构建
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **被动转储**: 非侵入式内存分析
 - **实时追踪**: 可选的方法执行监控
 - **自动修复**: 内置 DEX 文件修复功能
-- **Native 层转储**: 支持从进程内存中转储 .so 动态库(含自映射的匿名 ELF 镜像),并自动修复段头以便静态分析
+- **Native 层转储**: 支持从进程内存中转储 .so 动态库(含自映射的匿名 ELF 镜像),并自动从 `.dynamic` 段重建完整的 section header 表,让 IDA/Ghidra 直接识别符号、导入导出与重定位
 - **高性能**: 使用无锁缓存和优化的字符串处理
 - **简化操作**: 智能默认配置，一条命令完成转储和修复
 
@@ -130,10 +130,12 @@ eBPFDexDumper [命令] [选项]
 
 **输出文件:**
 - **原始 .so**: `so_<pid>_<base>_<size>_<name>.so` 保存在输出目录下
-- **修复后的 .so**: `fix/so_<pid>_<base>_<size>_<name>_fix.so`,重写了 `PT_LOAD` 段的 `p_offset`/`p_filesz` 并清空过期的节头信息,便于 IDA/Ghidra 等工具直接加载分析
+- **修复后的 .so**: `fix/so_<pid>_<base>_<size>_<name>_fix.so`,已重建完整的 section header 表,可直接丢进 IDA/Ghidra 分析
 
 ### `fixso` 命令
-扫描目录中转储的 .so 文件并修复段头。
+扫描目录中转储的 .so 文件并修复,使其可被 IDA 正确识别。
+
+修复思路参考了 [SoFixer](https://github.com/F8LEFT/SoFixer) 但针对 ARM64/ELF64 重写:内存 dump 出来的 so 丢失了 section header 表(加载器不映射它),IDA 只能靠 program header 勉强加载,符号/PLT/GOT 识别不全。本工具会先把 `PT_LOAD` 段的 `p_offset` 归一化到 `p_vaddr`,再**解析 `PT_DYNAMIC` 段**,从 `DT_SYMTAB/STRTAB/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY` 等 tag 反推出 `.dynsym`/`.dynstr`/`.rela.dyn`/`.rela.plt`/`.relr.dyn`/`.dynamic` 等 section 的地址与大小,按地址排序后补全各 section 尺寸,并把符号表里指向原始布局的 `st_shndx` 重映射到重建后的 section,最终追加一张完整的 section header 表。这样 IDA 就能像加载正常 so 一样识别符号、导入导出与重定位。若目标缺少 `PT_DYNAMIC` 无法重建,则自动回退到仅归一化 `p_offset` + 清空 section header 的兜底方案。
 
 **选项:**
 - `--dir, -d <dir>` - 包含转储 .so 文件的目录(必需)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **被动转储**: 非侵入式内存分析
 - **实时追踪**: 可选的方法执行监控
 - **自动修复**: 内置 DEX 文件修复功能
-- **Native 层转储**: 支持从进程内存中转储 .so 动态库(含自映射的匿名 ELF 镜像),并自动从 `.dynamic` 段重建完整的 section header 表,让 IDA/Ghidra 直接识别符号、导入导出与重定位
+- **Native 层转储与修复**: 从进程内存转储 .so 动态库(含自映射的匿名 ELF 镜像),自动从 `.dynamic` 段重建完整 section header 表,让 IDA/Ghidra 直接识别符号、导入导出与重定位。支持 **ARM64/ELF64 与 ARM32/ELF32**、**Android packed 重定位**(APS2 / RELR),可 **watch 运行时解密**、按需**过滤系统库**
 - **高性能**: 使用无锁缓存和优化的字符串处理
 - **简化操作**: 智能默认配置，一条命令完成转储和修复
 
@@ -104,7 +104,7 @@ eBPFDexDumper [命令] [选项]
 ![alt text](img/image-fix.png)
 
 ### `dumpso` 命令
-从目标进程内存中转储 native .so 动态库。与 `dump` 不同,这个功能不依赖 eBPF/uprobe,而是直接解析目标进程的 `/proc/<pid>/maps`,把同一个库分散映射的多个内存段(r--/r-x/rw-)合并还原成完整镜像,再通过 `process_vm_readv` 读出。默认还会扫描没有文件路径的匿名内存区域,只要其起始页是 ELF 魔数(`\x7fELF`),就当作自映射/自解密的库一并转储——这类不走标准动态链接器加载路径的场景,常见于对 native 层做了加固/VMP 的应用。您必须提供 `--uid` 或 `--name` 之一来选择目标进程。
+从目标进程内存中转储 native .so 动态库。与 `dump` 不同,这个功能不依赖 eBPF/uprobe,而是直接解析目标进程的 `/proc/<pid>/maps`,把同一个库分散映射的多个内存段(r--/r-x/rw-)合并还原成完整镜像,再通过 `process_vm_readv` 读出。默认还会扫描没有文件路径的匿名内存区域,只要其起始页是 ELF 魔数(`\x7fELF`),就当作自映射/自解密的库一并转储——这类不走标准动态链接器加载路径的场景,常见于对 native 层做了加固/VMP 的应用。您必须提供 `--uid` 或 `--name` 之一来选择目标进程。默认会跳过 `/system`、`/apex`、`/vendor` 等固件分区的库(它们可直接从设备镜像获取),用 `--include-system` 可保留;对运行时才解密映射的加固 so,可用 `--watch` 持续监控进程,新模块一出现就立即转储。
 
 **选项:**
 - `--uid, -u <uid>` - 按 UID 过滤(`--name` 的替代方案)
@@ -115,6 +115,10 @@ eBPFDexDumper [命令] [选项]
 - `--auto-fix, -f` - 转储完成后自动修复 .so 文件(默认值:**true**)
 - `--no-anon` - 禁用匿名 ELF 区域扫描
 - `--no-auto-fix` - 禁用自动修复
+- `--include-system` - 同时转储 `/system`、`/apex`、`/vendor` 下的系统库(默认跳过)
+- `--watch, -w` - 持续监控进程,模块一出现就转储(捕获运行时解密的库)
+- `--watch-interval <秒>` - `--watch` 模式下重新扫描 maps 的间隔(默认值:1)
+- `--watch-timeout <秒>` - `--watch` 运行多少秒后停止(0 = 直到中断,默认值:60)
 
 **示例:**
 ```bash
@@ -126,6 +130,9 @@ eBPFDexDumper [命令] [选项]
 
 # 关闭匿名 ELF 扫描，只处理正常动态链接的库
 ./eBPFDexDumper dumpso -n com.example.app --no-anon
+
+# 持续监控 120 秒,捕获运行时解密映射的加固 so
+./eBPFDexDumper dumpso -n com.example.app --watch --watch-timeout 120
 ```
 
 **输出文件:**
@@ -135,7 +142,7 @@ eBPFDexDumper [命令] [选项]
 ### `fixso` 命令
 扫描目录中转储的 .so 文件并修复,使其可被 IDA 正确识别。
 
-修复思路参考了 [SoFixer](https://github.com/F8LEFT/SoFixer) 但针对 ARM64/ELF64 重写:内存 dump 出来的 so 丢失了 section header 表(加载器不映射它),IDA 只能靠 program header 勉强加载,符号/PLT/GOT 识别不全。本工具会先把 `PT_LOAD` 段的 `p_offset` 归一化到 `p_vaddr`,再**解析 `PT_DYNAMIC` 段**,从 `DT_SYMTAB/STRTAB/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY` 等 tag 反推出 `.dynsym`/`.dynstr`/`.rela.dyn`/`.rela.plt`/`.relr.dyn`/`.dynamic` 等 section 的地址与大小,按地址排序后补全各 section 尺寸,并把符号表里指向原始布局的 `st_shndx` 重映射到重建后的 section,最终追加一张完整的 section header 表。这样 IDA 就能像加载正常 so 一样识别符号、导入导出与重定位。若目标缺少 `PT_DYNAMIC` 无法重建,则自动回退到仅归一化 `p_offset` + 清空 section header 的兜底方案。
+修复思路参考了 [SoFixer](https://github.com/F8LEFT/SoFixer) 但针对 Android(含 ARM64/ELF64 与 ARM32/ELF32)重写:内存 dump 出来的 so 丢失了 section header 表(加载器不映射它),IDA 只能靠 program header 勉强加载,符号/PLT/GOT 识别不全。本工具会先把 `PT_LOAD` 段的 `p_offset` 归一化到 `p_vaddr`,再**解析 `PT_DYNAMIC` 段**,从 `DT_SYMTAB/STRTAB/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY` 等 tag 反推出 `.dynsym`/`.dynstr`/`.rela.dyn`/`.rela.plt`/`.relr.dyn`/`.dynamic` 等 section 的地址与大小,按地址排序后补全各 section 尺寸,并把符号表里指向原始布局的 `st_shndx` 重映射到重建后的 section,最终追加一张完整的 section header 表。这样 IDA 就能像加载正常 so 一样识别符号、导入导出与重定位。整个流程同时支持 **ARM64/ELF64 与 ARM32/ELF32** 两种位宽(自动按 `EI_CLASS` 处理 REL/RELA 差异),并识别 **Android packed 重定位**(`DT_ANDROID_REL/RELA`,APS2 压缩)、**RELR** 压缩相对重定位与 **VERDEF** 版本定义;重建完成后会用严格的 ELF 解析器自检,报告可读的动态符号数。若目标缺少 `PT_DYNAMIC` 无法重建,则自动回退到仅归一化 `p_offset` + 清空 section header 的兜底方案(同样兼容 32/64 位)。
 
 **选项:**
 - `--dir, -d <dir>` - 包含转储 .so 文件的目录(必需)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ eBPFDexDumper [命令] [选项]
 - `--no-anon` - 禁用匿名 ELF 区域扫描
 - `--no-auto-fix` - 禁用自动修复
 - `--include-system` - 同时转储 `/system`、`/apex`、`/vendor` 下的系统库(默认跳过)
-- `--watch, -w` - 持续监控进程,模块一出现就转储(捕获运行时解密的库)
+- `--watch, -w` - 持续监控进程,模块一出现就转储,内容变化(如原地解密)时再次转储(捕获运行时解密的库)
 - `--watch-interval <秒>` - `--watch` 模式下重新扫描 maps 的间隔(默认值:1)
 - `--watch-timeout <秒>` - `--watch` 运行多少秒后停止(0 = 直到中断,默认值:60)
 
@@ -146,7 +146,7 @@ eBPFDexDumper [命令] [选项]
 
 **选项:**
 - `--dir, -d <dir>` - 包含转储 .so 文件的目录(必需)
-- `--symbols, -s <file>` - 注入符号映射文件(每行 `偏移 名字`),写入真实 `.symtab`,常用于恢复 JNI 函数名
+- `--symbols, -s <file>` - 注入符号映射文件(每行 `偏移 名字`),写入真实 `.symtab`,常用于恢复 JNI 函数名。文件名形如 `jni_symbols_<模块>.txt` 时,符号只注入到名字匹配的那个 .so,不会污染同目录里的其它库
 
 **示例:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -146,11 +146,35 @@ eBPFDexDumper [命令] [选项]
 
 **选项:**
 - `--dir, -d <dir>` - 包含转储 .so 文件的目录(必需)
+- `--symbols, -s <file>` - 注入符号映射文件(每行 `偏移 名字`),写入真实 `.symtab`,常用于恢复 JNI 函数名
 
 **示例:**
 ```bash
 ./eBPFDexDumper fixso -d /data/local/tmp/so_out
+
+# 注入 dump 阶段抓到的 JNI 符号,让 IDA 显示真实函数名
+./eBPFDexDumper fixso -d /data/local/tmp/so_out -s /data/local/tmp/dex_out/jni_symbols_libxxx.txt
 ```
+
+### JNI 符号恢复(动态注册)
+
+大量加固/正常 app 通过 `RegisterNatives` **动态注册** JNI 函数,这些函数在 .so 里没有导出符号,IDA 只显示 `sub_XXXX`。本工具在 `dump`(DEX 脱壳)运行时用 eBPF uprobe 挂 libart 的 `RegisterNatives`,抓取 `{函数指针, 方法名, 签名}`,按模块解析成 `偏移 名字` 写到输出目录的 `jni_symbols_<模块>.txt`;再用 `fixso --symbols` 注入到对应 dump 的 so,IDA 便能显示真实的 JNI 函数名。
+
+```bash
+# 1) 脱壳(同时抓 JNI 映射,生成 jni_symbols_*.txt)
+./eBPFDexDumper dump -n com.example.app
+# 2) 转储 native so
+./eBPFDexDumper dumpso -n com.example.app -o /data/local/tmp/so_out
+# 3) 修复并注入 JNI 符号
+./eBPFDexDumper fixso -d /data/local/tmp/so_out -s /data/local/tmp/dex_out/jni_symbols_libnative.txt
+```
+
+> 注:eBPF 抓取依赖 ARM64 真机(需设备实测);`.symtab` 注入本身与架构无关,可注入任意来源(eBPF/Frida/手工)的 `偏移 名字` 映射。
+
+### 限制与后续
+
+- **CompactDex(cdex)**:高版本 ART 的压缩 DEX 格式。本工具会**检测并给出提示**,但暂不做 `cdex→dex` 完整转换(CodeItem 需解压重组);遇到时请先用 [vdexExtractor](https://github.com/anestisb/vdexExtractor) 等工具转换。
+- **抽取型加固的主动触发**:eBPF 是**只读观测**模型,无法主动调用目标进程的方法去强制解密未执行的方法体;这类"主动脱壳"需要代码注入(如 Frida/ptrace),不在本工具的 eBPF 模型内。当前 `dump` 只捕获**运行时被执行到**的方法。
 
 ## 安装与构建
 

--- a/README_en.md
+++ b/README_en.md
@@ -12,7 +12,7 @@ Android in-memory DEX dumper powered by eBPF technology.
 - **Passive dump**: Non-intrusive memory analysis
 - **Real-time tracing**: Optional method execution monitoring
 - **Automatic fixing**: Built-in DEX file repair functionality
-- **Native-layer dumping**: Dump .so libraries straight out of process memory (including self-mapped anonymous ELF images), automatically rebuilding a full section header table from the `.dynamic` segment so IDA/Ghidra recognize symbols, imports/exports and relocations
+- **Native-layer dump & fix**: Dump .so libraries straight out of process memory (including self-mapped anonymous ELF images) and rebuild a full section header table from the `.dynamic` segment so IDA/Ghidra recognize symbols, imports/exports and relocations. Handles **ARM64/ELF64 and ARM32/ELF32**, **Android packed relocations** (APS2 / RELR), can **watch for runtime decryption**, and skips firmware libraries by default
 - **High performance**: Lock-free caching and optimized string processing
 - **Simplified operation**: Smart defaults, dump and fix in one command
 
@@ -102,7 +102,7 @@ Scan a directory for dumped DEX files and fix headers/structures for readability
 ```
 
 ### `dumpso` Command
-Dump native .so libraries from a target process's memory. Unlike `dump`, this does not rely on eBPF/uprobes: it parses the target process's `/proc/<pid>/maps` directly, merges a library's separately-mapped segments (r--/r-x/rw-) back into one contiguous image, and reads it out via `process_vm_readv`. By default it also scans path-less (anonymous) memory regions and treats any whose first page starts with the ELF magic (`\x7fELF`) as a self-mapped/self-decrypted library to dump as well - useful against apps whose native-layer hardening/VMP doesn't load libraries through the normal dynamic linker path. You must provide either `--uid` or `--name` to select the target process(es).
+Dump native .so libraries from a target process's memory. Unlike `dump`, this does not rely on eBPF/uprobes: it parses the target process's `/proc/<pid>/maps` directly, merges a library's separately-mapped segments (r--/r-x/rw-) back into one contiguous image, and reads it out via `process_vm_readv`. By default it also scans path-less (anonymous) memory regions and treats any whose first page starts with the ELF magic (`\x7fELF`) as a self-mapped/self-decrypted library to dump as well - useful against apps whose native-layer hardening/VMP doesn't load libraries through the normal dynamic linker path. You must provide either `--uid` or `--name` to select the target process(es). Firmware-partition libraries under `/system`, `/apex`, `/vendor` are skipped by default (they can be pulled off the device image); use `--include-system` to keep them. For hardeners that only decrypt and map a library at runtime, `--watch` keeps polling the process and dumps each new module the moment it appears.
 
 **Options:**
 - `--uid, -u <uid>` - Filter by UID (alternative to `--name`)
@@ -113,6 +113,10 @@ Dump native .so libraries from a target process's memory. Unlike `dump`, this do
 - `--auto-fix, -f` - Automatically fix dumped .so files after dumping (default: **true**)
 - `--no-anon` - Disable anonymous ELF region scanning
 - `--no-auto-fix` - Disable automatic .so fixing
+- `--include-system` - Also dump system libraries under `/system`, `/apex`, `/vendor` (skipped by default)
+- `--watch, -w` - Keep watching the process and dump modules as they appear (captures runtime-decrypted libs)
+- `--watch-interval <sec>` - Seconds between map re-scans in `--watch` mode (default: 1)
+- `--watch-timeout <sec>` - Stop `--watch` after N seconds (0 = until interrupted, default: 60)
 
 **Examples:**
 ```bash
@@ -124,6 +128,9 @@ Dump native .so libraries from a target process's memory. Unlike `dump`, this do
 
 # Skip anonymous ELF scanning, only handle normally-linked libraries
 ./eBPFDexDumper dumpso -n com.example.app --no-anon
+
+# Watch for 120s to catch a runtime-decrypted, self-mapped hardened .so
+./eBPFDexDumper dumpso -n com.example.app --watch --watch-timeout 120
 ```
 
 **Output Files:**
@@ -133,7 +140,7 @@ Dump native .so libraries from a target process's memory. Unlike `dump`, this do
 ### `fixso` Command
 Scan a directory for dumped .so files and repair them so IDA recognizes them.
 
-The approach is inspired by [SoFixer](https://github.com/F8LEFT/SoFixer) but rewritten for ARM64/ELF64: a memory-dumped .so has lost its section header table (the loader never maps it), so IDA can only load it via program headers and misses many symbols/PLT/GOT entries. This tool first normalizes each `PT_LOAD` segment's `p_offset` to `p_vaddr`, then **parses the `PT_DYNAMIC` segment** and reconstructs the addresses and sizes of `.dynsym`/`.dynstr`/`.rela.dyn`/`.rela.plt`/`.relr.dyn`/`.dynamic` and friends from the `DT_SYMTAB/STRTAB/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY` tags. Sections are sorted by address to fill in unknown sizes, each symbol's `st_shndx` (which pointed at the original layout) is remapped to the rebuilt section that contains it, and a complete section header table is appended. IDA then recognizes symbols, imports/exports and relocations just like a normal .so. If the target has no `PT_DYNAMIC` and can't be rebuilt, it falls back to only normalizing `p_offset` and zeroing the section headers.
+The approach is inspired by [SoFixer](https://github.com/F8LEFT/SoFixer) but rewritten for Android (both ARM64/ELF64 and ARM32/ELF32): a memory-dumped .so has lost its section header table (the loader never maps it), so IDA can only load it via program headers and misses many symbols/PLT/GOT entries. This tool first normalizes each `PT_LOAD` segment's `p_offset` to `p_vaddr`, then **parses the `PT_DYNAMIC` segment** and reconstructs the addresses and sizes of `.dynsym`/`.dynstr`/`.rela.dyn`/`.rela.plt`/`.relr.dyn`/`.dynamic` and friends from the `DT_SYMTAB/STRTAB/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY` tags. Sections are sorted by address to fill in unknown sizes, each symbol's `st_shndx` (which pointed at the original layout) is remapped to the rebuilt section that contains it, and a complete section header table is appended. IDA then recognizes symbols, imports/exports and relocations just like a normal .so. The whole flow handles **both ELF32 and ELF64** (picking REL vs RELA by `EI_CLASS`) and also decodes **Android packed relocations** (`DT_ANDROID_REL/RELA`, APS2), **RELR** compressed relative relocations and **VERDEF** version definitions; after rebuilding it self-checks the output with a strict ELF parser and reports how many dynamic symbols are readable. If the target has no `PT_DYNAMIC` and can't be rebuilt, it falls back to only normalizing `p_offset` and zeroing the section headers (class-aware for 32- and 64-bit alike).
 
 **Options:**
 - `--dir, -d <dir>` - Directory containing dumped .so files (required)

--- a/README_en.md
+++ b/README_en.md
@@ -144,11 +144,35 @@ The approach is inspired by [SoFixer](https://github.com/F8LEFT/SoFixer) but rew
 
 **Options:**
 - `--dir, -d <dir>` - Directory containing dumped .so files (required)
+- `--symbols, -s <file>` - Symbol map file (`offset name` per line) to inject into a real `.symtab`; typically used to recover JNI names
 
 **Example:**
 ```bash
 ./eBPFDexDumper fixso -d /data/local/tmp/so_out
+
+# Inject JNI symbols captured during dumping so IDA shows real function names
+./eBPFDexDumper fixso -d /data/local/tmp/so_out -s /data/local/tmp/dex_out/jni_symbols_libxxx.txt
 ```
+
+### JNI symbol recovery (dynamic registration)
+
+Many hardeners (and ordinary apps) register JNI functions **dynamically** via `RegisterNatives`; those functions carry no export symbol in the .so, so IDA only shows `sub_XXXX`. During `dump` (DEX unpacking) this tool attaches an eBPF uprobe to libart's `RegisterNatives`, captures `{fnPtr, method name, signature}`, resolves each to a module offset, and writes `jni_symbols_<module>.txt` under the output dir. Feed that to `fixso --symbols` to inject the names, and IDA shows the real JNI function names.
+
+```bash
+# 1) Unpack (also captures the JNI map into jni_symbols_*.txt)
+./eBPFDexDumper dump -n com.example.app
+# 2) Dump native .so
+./eBPFDexDumper dumpso -n com.example.app -o /data/local/tmp/so_out
+# 3) Fix and inject JNI symbols
+./eBPFDexDumper fixso -d /data/local/tmp/so_out -s /data/local/tmp/dex_out/jni_symbols_libnative.txt
+```
+
+> Note: the eBPF capture side needs an ARM64 device to run (verify on-device); the `.symtab` injection itself is architecture-independent and accepts an `offset name` map from any source (eBPF/Frida/manual).
+
+### Limitations & future work
+
+- **CompactDex (cdex)**: newer ART's compressed DEX format. This tool **detects and warns** about it but does not yet do a full `cdex→dex` conversion (CodeItems need decompression/relayout); convert with a tool like [vdexExtractor](https://github.com/anestisb/vdexExtractor) first.
+- **Active triggering for extraction-based packers**: eBPF is a **read-only** observation model — it cannot call into the target to force-decrypt methods that never execute. That kind of active unpacking needs code injection (Frida/ptrace), which is outside this tool's eBPF model. Today `dump` captures only methods that actually run.
 
 ## Installation & Build
 

--- a/README_en.md
+++ b/README_en.md
@@ -114,7 +114,7 @@ Dump native .so libraries from a target process's memory. Unlike `dump`, this do
 - `--no-anon` - Disable anonymous ELF region scanning
 - `--no-auto-fix` - Disable automatic .so fixing
 - `--include-system` - Also dump system libraries under `/system`, `/apex`, `/vendor` (skipped by default)
-- `--watch, -w` - Keep watching the process and dump modules as they appear (captures runtime-decrypted libs)
+- `--watch, -w` - Keep watching the process and dump modules as they appear, re-dumping when their contents change (e.g. in-place decryption) (captures runtime-decrypted libs)
 - `--watch-interval <sec>` - Seconds between map re-scans in `--watch` mode (default: 1)
 - `--watch-timeout <sec>` - Stop `--watch` after N seconds (0 = until interrupted, default: 60)
 
@@ -144,7 +144,7 @@ The approach is inspired by [SoFixer](https://github.com/F8LEFT/SoFixer) but rew
 
 **Options:**
 - `--dir, -d <dir>` - Directory containing dumped .so files (required)
-- `--symbols, -s <file>` - Symbol map file (`offset name` per line) to inject into a real `.symtab`; typically used to recover JNI names
+- `--symbols, -s <file>` - Symbol map file (`offset name` per line) to inject into a real `.symtab`; typically used to recover JNI names. When named `jni_symbols_<module>.txt`, the symbols are injected only into the matching .so, so the other dumped libraries in the directory aren't polluted
 
 **Example:**
 ```bash

--- a/README_en.md
+++ b/README_en.md
@@ -12,7 +12,7 @@ Android in-memory DEX dumper powered by eBPF technology.
 - **Passive dump**: Non-intrusive memory analysis
 - **Real-time tracing**: Optional method execution monitoring
 - **Automatic fixing**: Built-in DEX file repair functionality
-- **Native-layer dumping**: Dump .so libraries straight out of process memory (including self-mapped anonymous ELF images), with automatic segment-header fixing for static analysis
+- **Native-layer dumping**: Dump .so libraries straight out of process memory (including self-mapped anonymous ELF images), automatically rebuilding a full section header table from the `.dynamic` segment so IDA/Ghidra recognize symbols, imports/exports and relocations
 - **High performance**: Lock-free caching and optimized string processing
 - **Simplified operation**: Smart defaults, dump and fix in one command
 
@@ -128,10 +128,12 @@ Dump native .so libraries from a target process's memory. Unlike `dump`, this do
 
 **Output Files:**
 - **Raw .so**: `so_<pid>_<base>_<size>_<name>.so` saved under the output directory
-- **Fixed .so**: `fix/so_<pid>_<base>_<size>_<name>_fix.so`, with each `PT_LOAD` segment's `p_offset`/`p_filesz` rewritten and stale section-header fields cleared so IDA/Ghidra and similar tools can load it directly
+- **Fixed .so**: `fix/so_<pid>_<base>_<size>_<name>_fix.so`, with a full section header table rebuilt so it drops straight into IDA/Ghidra
 
 ### `fixso` Command
-Scan a directory for dumped .so files and fix their segment headers.
+Scan a directory for dumped .so files and repair them so IDA recognizes them.
+
+The approach is inspired by [SoFixer](https://github.com/F8LEFT/SoFixer) but rewritten for ARM64/ELF64: a memory-dumped .so has lost its section header table (the loader never maps it), so IDA can only load it via program headers and misses many symbols/PLT/GOT entries. This tool first normalizes each `PT_LOAD` segment's `p_offset` to `p_vaddr`, then **parses the `PT_DYNAMIC` segment** and reconstructs the addresses and sizes of `.dynsym`/`.dynstr`/`.rela.dyn`/`.rela.plt`/`.relr.dyn`/`.dynamic` and friends from the `DT_SYMTAB/STRTAB/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY` tags. Sections are sorted by address to fill in unknown sizes, each symbol's `st_shndx` (which pointed at the original layout) is remapped to the rebuilt section that contains it, and a complete section header table is appended. IDA then recognizes symbols, imports/exports and relocations just like a normal .so. If the target has no `PT_DYNAMIC` and can't be rebuilt, it falls back to only normalizing `p_offset` and zeroing the section headers.
 
 **Options:**
 - `--dir, -d <dir>` - Directory containing dumped .so files (required)

--- a/README_en.md
+++ b/README_en.md
@@ -12,6 +12,7 @@ Android in-memory DEX dumper powered by eBPF technology.
 - **Passive dump**: Non-intrusive memory analysis
 - **Real-time tracing**: Optional method execution monitoring
 - **Automatic fixing**: Built-in DEX file repair functionality
+- **Native-layer dumping**: Dump .so libraries straight out of process memory (including self-mapped anonymous ELF images), with automatic segment-header fixing for static analysis
 - **High performance**: Lock-free caching and optimized string processing
 - **Simplified operation**: Smart defaults, dump and fix in one command
 
@@ -41,6 +42,8 @@ eBPFDexDumper [command] [options]
 **Available Commands:**
 - `dump` - Start eBPF-based DEX dumper
 - `fix` - Fix dumped DEX files in a directory
+- `dumpso` - Dump native .so libraries from a running process's memory
+- `fixso` - Fix dumped .so files in a directory
 
 ### `dump` Command
 Attach uprobes to libart and stream DEX/method events. You must provide either `--uid` or `--name` to filter the target app.
@@ -96,6 +99,46 @@ Scan a directory for dumped DEX files and fix headers/structures for readability
 **Example:**
 ```bash
 ./eBPFDexDumper fix -d /data/local/tmp/out
+```
+
+### `dumpso` Command
+Dump native .so libraries from a target process's memory. Unlike `dump`, this does not rely on eBPF/uprobes: it parses the target process's `/proc/<pid>/maps` directly, merges a library's separately-mapped segments (r--/r-x/rw-) back into one contiguous image, and reads it out via `process_vm_readv`. By default it also scans path-less (anonymous) memory regions and treats any whose first page starts with the ELF magic (`\x7fELF`) as a self-mapped/self-decrypted library to dump as well - useful against apps whose native-layer hardening/VMP doesn't load libraries through the normal dynamic linker path. You must provide either `--uid` or `--name` to select the target process(es).
+
+**Options:**
+- `--uid, -u <uid>` - Filter by UID (alternative to `--name`)
+- `--name, -n <package>` - Android package name to derive UID (alternative to `--uid`)
+- `--lib, -l <substr>` - Only dump libraries whose path contains this substring (default: all app-mapped .so files)
+- `--out, -o, --output <dir>` - Output directory on device (default: `/data/local/tmp/so_out`)
+- `--anon, -a` - Also scan anonymous memory regions for self-mapped ELF images (default: **true**)
+- `--auto-fix, -f` - Automatically fix dumped .so files after dumping (default: **true**)
+- `--no-anon` - Disable anonymous ELF region scanning
+- `--no-auto-fix` - Disable automatic .so fixing
+
+**Examples:**
+```bash
+# Simplest usage - dump every .so mapped by the app's process(es), auto-fix
+./eBPFDexDumper dumpso -n com.example.app
+
+# Dump one specific library
+./eBPFDexDumper dumpso -n com.example.app -l libnative-lib.so
+
+# Skip anonymous ELF scanning, only handle normally-linked libraries
+./eBPFDexDumper dumpso -n com.example.app --no-anon
+```
+
+**Output Files:**
+- **Raw .so**: `so_<pid>_<base>_<size>_<name>.so` saved under the output directory
+- **Fixed .so**: `fix/so_<pid>_<base>_<size>_<name>_fix.so`, with each `PT_LOAD` segment's `p_offset`/`p_filesz` rewritten and stale section-header fields cleared so IDA/Ghidra and similar tools can load it directly
+
+### `fixso` Command
+Scan a directory for dumped .so files and fix their segment headers.
+
+**Options:**
+- `--dir, -d <dir>` - Directory containing dumped .so files (required)
+
+**Example:**
+```bash
+./eBPFDexDumper fixso -d /data/local/tmp/so_out
 ```
 
 ## Installation & Build

--- a/bpf.c
+++ b/bpf.c
@@ -246,10 +246,15 @@ bool trace_allowed(u32 pid, u32 uid)
     return true;
 }
 
-// JNINativeMethod is ABI-stable across Android versions:
+// JNINativeMethod for a 64-bit (ARM64/ELF64) process. The field offsets and the
+// 24-byte stride below assume 8-byte pointers:
 //   const char* name;      // +0
 //   const char* signature; // +8
 //   void*       fnPtr;     // +16
+// The uprobe attaches to the 64-bit lib64 libart by default, so it only fires
+// for 64-bit targets. A 32-bit (armeabi-v7a) process has a 12-byte struct with
+// 4-byte fields; there the reads below fail safe (out-of-range pointers ->
+// empty name -> dropped by the Go side) instead of emitting wrong symbols.
 #define JNI_NATIVE_METHOD_SIZE 24
 #define JNI_MAX_METHODS 512
 
@@ -262,7 +267,11 @@ bool trace_allowed(u32 pid, u32 uid)
 SEC("uprobe/libart_registerNatives")
 int uprobe_libart_registerNatives(struct pt_regs *ctx)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    // Use the TGID (process id), not the low-32 TID: writeJniSymbols resolves
+    // fn_ptr against /proc/<pid>/maps later, at Stop. A registering worker
+    // thread may have exited by then, but the thread-group leader (tgid) lives
+    // for the whole process and shares the same address space.
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
     if (!trace_allowed(0, bpf_get_current_uid_gid())) {
         return 0;
     }
@@ -290,10 +299,12 @@ int uprobe_libart_registerNatives(struct pt_regs *ctx)
         if (!e) {
             continue;
         }
+        // bpf_ringbuf_reserve does not zero the record; clear it so the bytes
+        // after each string's NUL aren't stale ring-buffer contents leaked to
+        // userspace (and so a failed read_user_str leaves a clean empty string).
+        __builtin_memset(e, 0, sizeof(*e));
         e->pid = pid;
         e->fn_ptr = fn_ptr;
-        e->name[0] = 0;
-        e->sig[0] = 0;
         if (name_ptr) {
             bpf_probe_read_user_str(e->name, sizeof(e->name), (void *)name_ptr);
         }

--- a/bpf.c
+++ b/bpf.c
@@ -8,6 +8,7 @@ const struct method_event_data_t *unused_method_event_data_t __attribute__((unus
 const buf_t *unused_buf_t __attribute__((unused));
 const struct dex_chunk_event_t *unused_dex_chunk_event_t __attribute__((unused));
 const struct dex_read_failure_t *unused_dex_read_failure_t __attribute__((unused));
+const struct jni_method_event_t *unused_jni_method_event_t __attribute__((unused));
 
 static int config_loaded = 0;
 static bool filter_enable = false;
@@ -243,6 +244,65 @@ bool trace_allowed(u32 pid, u32 uid)
 		}
 	}
     return true;
+}
+
+// JNINativeMethod is ABI-stable across Android versions:
+//   const char* name;      // +0
+//   const char* signature; // +8
+//   void*       fnPtr;     // +16
+#define JNI_NATIVE_METHOD_SIZE 24
+#define JNI_MAX_METHODS 512
+
+// uprobe on art::JNI<>::RegisterNatives(JNIEnv*, jclass, const JNINativeMethod*,
+// jint). Walks the methods array and emits {fn_ptr, name, sig} for each, so the
+// Go side can recover names for dynamically-registered JNI functions (which
+// carry no export symbol in the .so). The class pointer (PARM2) is deliberately
+// not dereferenced: resolving it needs version-specific ART mirror layout,
+// whereas the JNINativeMethod fields are plain C strings/pointers.
+SEC("uprobe/libart_registerNatives")
+int uprobe_libart_registerNatives(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    if (!trace_allowed(0, bpf_get_current_uid_gid())) {
+        return 0;
+    }
+
+    unsigned char *methods = (unsigned char *)PT_REGS_PARM3(ctx);
+    int count = (int)PT_REGS_PARM4(ctx);
+    if (methods == 0 || count <= 0) {
+        return 0;
+    }
+    if (count > JNI_MAX_METHODS) {
+        count = JNI_MAX_METHODS;
+    }
+
+    for (int i = 0; i < count && i < JNI_MAX_METHODS; i++) {
+        unsigned char *entry = methods + (long)i * JNI_NATIVE_METHOD_SIZE;
+        u64 name_ptr = 0, sig_ptr = 0, fn_ptr = 0;
+        bpf_probe_read_user(&name_ptr, sizeof(u64), entry + 0);
+        bpf_probe_read_user(&sig_ptr, sizeof(u64), entry + 8);
+        bpf_probe_read_user(&fn_ptr, sizeof(u64), entry + 16);
+        if (fn_ptr == 0) {
+            continue;
+        }
+        struct jni_method_event_t *e =
+            (struct jni_method_event_t *)bpf_ringbuf_reserve(&jni_events, sizeof(struct jni_method_event_t), 0);
+        if (!e) {
+            continue;
+        }
+        e->pid = pid;
+        e->fn_ptr = fn_ptr;
+        e->name[0] = 0;
+        e->sig[0] = 0;
+        if (name_ptr) {
+            bpf_probe_read_user_str(e->name, sizeof(e->name), (void *)name_ptr);
+        }
+        if (sig_ptr) {
+            bpf_probe_read_user_str(e->sig, sizeof(e->sig), (void *)sig_ptr);
+        }
+        bpf_ringbuf_submit(e, 0);
+    }
+    return 0;
 }
 
 SEC("uprobe/libart_execute")

--- a/bpf_arm64_bpfel.go
+++ b/bpf_arm64_bpfel.go
@@ -44,6 +44,14 @@ type bpfDexReadFailureT struct {
 	_            [4]byte
 }
 
+type bpfJniMethodEventT struct {
+	Pid   uint32
+	_     [4]byte
+	FnPtr uint64
+	Name  [96]int8
+	Sig   [96]int8
+}
+
 type bpfMethodEventDataT struct {
 	Begin        uint64
 	Pid          uint32
@@ -98,6 +106,7 @@ type bpfProgramSpecs struct {
 	UprobeLibartExecute          *ebpf.ProgramSpec `ebpf:"uprobe_libart_execute"`
 	UprobeLibartExecuteNterpImpl *ebpf.ProgramSpec `ebpf:"uprobe_libart_executeNterpImpl"`
 	UprobeLibartNterpOpInvoke    *ebpf.ProgramSpec `ebpf:"uprobe_libart_nterpOpInvoke"`
+	UprobeLibartRegisterNatives  *ebpf.ProgramSpec `ebpf:"uprobe_libart_registerNatives"`
 	UprobeLibartVerifyClass      *ebpf.ProgramSpec `ebpf:"uprobe_libart_verifyClass"`
 }
 
@@ -111,6 +120,7 @@ type bpfMapSpecs struct {
 	DexProgressMap     *ebpf.MapSpec `ebpf:"dexProgress_map"`
 	DexChunks          *ebpf.MapSpec `ebpf:"dex_chunks"`
 	Events             *ebpf.MapSpec `ebpf:"events"`
+	JniEvents          *ebpf.MapSpec `ebpf:"jni_events"`
 	MethodCodeCacheMap *ebpf.MapSpec `ebpf:"methodCodeCache_map"`
 	MethodEvents       *ebpf.MapSpec `ebpf:"method_events"`
 	ReadFailures       *ebpf.MapSpec `ebpf:"read_failures"`
@@ -141,6 +151,7 @@ type bpfMaps struct {
 	DexProgressMap     *ebpf.Map `ebpf:"dexProgress_map"`
 	DexChunks          *ebpf.Map `ebpf:"dex_chunks"`
 	Events             *ebpf.Map `ebpf:"events"`
+	JniEvents          *ebpf.Map `ebpf:"jni_events"`
 	MethodCodeCacheMap *ebpf.Map `ebpf:"methodCodeCache_map"`
 	MethodEvents       *ebpf.Map `ebpf:"method_events"`
 	ReadFailures       *ebpf.Map `ebpf:"read_failures"`
@@ -154,6 +165,7 @@ func (m *bpfMaps) Close() error {
 		m.DexProgressMap,
 		m.DexChunks,
 		m.Events,
+		m.JniEvents,
 		m.MethodCodeCacheMap,
 		m.MethodEvents,
 		m.ReadFailures,
@@ -167,6 +179,7 @@ type bpfPrograms struct {
 	UprobeLibartExecute          *ebpf.Program `ebpf:"uprobe_libart_execute"`
 	UprobeLibartExecuteNterpImpl *ebpf.Program `ebpf:"uprobe_libart_executeNterpImpl"`
 	UprobeLibartNterpOpInvoke    *ebpf.Program `ebpf:"uprobe_libart_nterpOpInvoke"`
+	UprobeLibartRegisterNatives  *ebpf.Program `ebpf:"uprobe_libart_registerNatives"`
 	UprobeLibartVerifyClass      *ebpf.Program `ebpf:"uprobe_libart_verifyClass"`
 }
 
@@ -175,6 +188,7 @@ func (p *bpfPrograms) Close() error {
 		p.UprobeLibartExecute,
 		p.UprobeLibartExecuteNterpImpl,
 		p.UprobeLibartNterpOpInvoke,
+		p.UprobeLibartRegisterNatives,
 		p.UprobeLibartVerifyClass,
 	)
 }

--- a/dex_parser.go
+++ b/dex_parser.go
@@ -13,6 +13,10 @@ import (
 // Dex文件格式常量
 const (
 	DexFileMagic = 0x0A786564
+	// CompactDexMagic is "cdex" — ART's CompactDex. Such files use a compressed
+	// CodeItem layout and shared data, so they need a cdex->dex conversion
+	// before standard DEX tooling can read them.
+	CompactDexMagic = 0x78656463
 
 	// String类型定义（保留以备后用）
 	TypeByte   = 0x00
@@ -116,6 +120,9 @@ func NewDexParser(data []byte) (*DexParser, error) {
 
 	// 验证魔数
 	magic := binary.LittleEndian.Uint32(parser.header.Magic[:4])
+	if magic == CompactDexMagic {
+		return nil, fmt.Errorf("CompactDex (cdex) detected: this tool emits standard DEX; a cdex->dex conversion is needed first (e.g. vdexExtractor) — see README")
+	}
 	if magic != DexFileMagic {
 		return nil, fmt.Errorf("invalid dex magic: %x", magic)
 	}

--- a/dumper.go
+++ b/dumper.go
@@ -29,6 +29,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -78,6 +79,20 @@ type DexDumper struct {
 	methodTaskChan chan methodTask
 	workerWg       sync.WaitGroup
 	stopped        atomic.Bool
+
+	// JNI RegisterNatives capture: names for dynamically-registered native
+	// methods, resolved to module offsets and written out at Stop.
+	jniMu      sync.Mutex
+	jniMethods []jniMethod
+}
+
+// jniMethod is one captured RegisterNatives entry. fnPtr is an absolute runtime
+// address, later resolved to a module-relative offset when symbols are written.
+type jniMethod struct {
+	pid   uint32
+	fnPtr uint64
+	name  string
+	sig   string
 }
 
 // JSON导出条目
@@ -227,6 +242,22 @@ func (dd *DexDumper) setupManager() error {
 		})
 	}
 
+	// RegisterNatives hook for JNI name recovery (best-effort: skipped when the
+	// symbol can't be located in libart, e.g. a stripped build).
+	if regNativesOff := FindRegisterNativesOffset(dd.libArtPath, 0); regNativesOff != 0 {
+		probes = append(probes, &manager.Probe{
+			UID:              "registerNatives",
+			EbpfFuncName:     "uprobe_libart_registerNatives",
+			Section:          "uprobe/libart_registerNatives",
+			BinaryPath:       dd.libArtPath,
+			UAddress:         regNativesOff,
+			AttachToFuncName: "RegisterNatives",
+		})
+		log.Printf("[+] JNI RegisterNatives hook enabled (libart offset 0x%x)", regNativesOff)
+	} else {
+		log.Printf("[-] RegisterNatives symbol not found in libart; JNI name recovery disabled")
+	}
+
 	dd.manager = &manager.Manager{
 		Probes: probes,
 		RingbufMaps: []*manager.RingbufMap{
@@ -260,6 +291,14 @@ func (dd *DexDumper) setupManager() error {
 				},
 				RingbufMapOptions: manager.RingbufMapOptions{
 					DataHandler: dd.handleReadFailureEventRingBuf,
+				},
+			},
+			{
+				Map: manager.Map{
+					Name: "jni_events",
+				},
+				RingbufMapOptions: manager.RingbufMapOptions{
+					DataHandler: dd.handleJniEventRingBuf,
 				},
 			},
 		},
@@ -339,6 +378,7 @@ func (dd *DexDumper) Stop() error {
 	dd.workerWg.Wait()
 
 	dd.flushJSON()
+	dd.writeJniSymbols()
 
 	// 自动修复DEX文件
 	if dd.autoFix {
@@ -614,6 +654,94 @@ func (dd *DexDumper) handleDexChunkEventRingBuf(CPU int, data []byte, ringBuf *m
 		return
 	}
 	dd.pendingDexMu.Unlock()
+}
+
+// handleJniEventRingBuf receives one RegisterNatives entry and records it for
+// later resolution to a module offset.
+func (dd *DexDumper) handleJniEventRingBuf(CPU int, data []byte, ringBuf *manager.RingbufMap, mgr *manager.Manager) {
+	if len(data) < int(unsafe.Sizeof(bpfJniMethodEventT{})) {
+		return
+	}
+	evt := bpfJniMethodEventT{}
+	if err := binary.Read(bytes.NewBuffer(data), binary.LittleEndian, &evt); err != nil {
+		return
+	}
+	name := goCStr(evt.Name[:])
+	if name == "" {
+		return
+	}
+	dd.jniMu.Lock()
+	dd.jniMethods = append(dd.jniMethods, jniMethod{pid: evt.Pid, fnPtr: evt.FnPtr, name: name, sig: goCStr(evt.Sig[:])})
+	dd.jniMu.Unlock()
+}
+
+// goCStr converts a NUL-terminated int8 buffer (as generated for eBPF char[]
+// event fields) to a Go string.
+func goCStr(b []int8) string {
+	n := 0
+	for n < len(b) && b[n] != 0 {
+		n++
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		out[i] = byte(b[i])
+	}
+	return string(out)
+}
+
+// writeJniSymbols resolves each captured JNI function pointer to the module that
+// owns it (via that process's /proc/<pid>/maps) and writes per-module
+// "offset name" files ready for `fixso --symbols`, plus a raw capture. Called at
+// Stop; a no-op if nothing was captured.
+func (dd *DexDumper) writeJniSymbols() {
+	dd.jniMu.Lock()
+	methods := append([]jniMethod(nil), dd.jniMethods...)
+	dd.jniMu.Unlock()
+	if len(methods) == 0 {
+		return
+	}
+
+	modCache := map[uint32][]soModule{}
+	getMods := func(pid uint32) []soModule {
+		if m, ok := modCache[pid]; ok {
+			return m
+		}
+		var mods []soModule
+		if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", pid)); err == nil {
+			mods = groupSoModules(parseMapEntries(string(data)), "", true, true, func(a uint64) bool { return peekIsElf(int(pid), a) })
+		}
+		modCache[pid] = mods
+		return mods
+	}
+
+	perMod := map[string]*bytes.Buffer{}
+	raw := &bytes.Buffer{}
+	seen := map[string]bool{}
+	for _, m := range methods {
+		key := fmt.Sprintf("%d_%x", m.pid, m.fnPtr)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		fmt.Fprintf(raw, "%d 0x%x %s %s\n", m.pid, m.fnPtr, m.name, m.sig)
+		for _, mod := range getMods(m.pid) {
+			if m.fnPtr >= mod.Base && m.fnPtr < mod.End {
+				b := perMod[mod.Name]
+				if b == nil {
+					b = &bytes.Buffer{}
+					perMod[mod.Name] = b
+				}
+				fmt.Fprintf(b, "0x%x %s\n", m.fnPtr-mod.Base, m.name)
+				break
+			}
+		}
+	}
+
+	_ = os.WriteFile(filepath.Join(outputPath, "jni_symbols_raw.txt"), raw.Bytes(), 0644)
+	for name, b := range perMod {
+		_ = os.WriteFile(filepath.Join(outputPath, "jni_symbols_"+sanitizeSoName(name)+".txt"), b.Bytes(), 0644)
+	}
+	log.Printf("[+] Captured %d JNI method(s) across %d module(s); wrote jni_symbols_*.txt under %s (feed to: fixso --symbols)", len(seen), len(perMod), outputPath)
 }
 
 func (dd *DexDumper) handleReadFailureEventRingBuf(CPU int, data []byte, ringBuf *manager.RingbufMap, mgr *manager.Manager) {

--- a/fix_so.go
+++ b/fix_so.go
@@ -110,13 +110,21 @@ func FixOneSo(soPath, outPath string, injected []InjectedSym) error {
 
 // FixSoDirectory scans dir for dumped .so files and writes fixed copies to
 // a "fix" subdirectory, mirroring FixDexDirectory's layout.
-func FixSoDirectory(dir string, injected []InjectedSym) error {
+//
+// injected symbols are module-relative, so they are only valid for one library.
+// symbolsTarget names that library (the module stem from a
+// jni_symbols_<stem>.txt file); symbols are injected only into the .so whose
+// name matches it, so the other dumped libraries aren't polluted with names at
+// offsets that mean nothing in their address space. An empty symbolsTarget with
+// a non-empty injected set means the origin couldn't be determined (e.g. a
+// hand-written map): fall back to injecting into every .so.
+func FixSoDirectory(dir string, injected []InjectedSym, symbolsTarget string) error {
 	fixDir := filepath.Join(dir, "fix")
 	if err := os.MkdirAll(fixDir, 0755); err != nil {
 		return fmt.Errorf("failed to create fix dir %s: %w", fixDir, err)
 	}
 
-	var count int
+	var count, injectedInto int
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -132,10 +140,20 @@ func FixSoDirectory(dir string, injected []InjectedSym) error {
 			return nil
 		}
 
+		// Route the symbol map only to its own library.
+		var syms []InjectedSym
+		if len(injected) > 0 && (symbolsTarget == "" || soMatchesModule(name, symbolsTarget)) {
+			syms = injected
+		}
+
 		outPath := filepath.Join(fixDir, strings.TrimSuffix(name, ".so")+"_fix.so")
-		if err := FixOneSo(path, outPath, injected); err != nil {
+		if err := FixOneSo(path, outPath, syms); err != nil {
 			fmt.Fprintf(os.Stdout, "[!] Fix failed for %s: %v\n", path, err)
 			return nil
+		}
+		if len(syms) > 0 {
+			injectedInto++
+			log.Printf("[+] Injected %d symbol(s) into %s", len(syms), name)
 		}
 		fmt.Fprintf(os.Stdout, "[+] Wrote %s\n", outPath)
 		count++
@@ -147,8 +165,20 @@ func FixSoDirectory(dir string, injected []InjectedSym) error {
 	if count == 0 {
 		return fmt.Errorf("no .so files found in %s", dir)
 	}
+	if len(injected) > 0 && symbolsTarget != "" && injectedInto == 0 {
+		log.Printf("[!] Symbol map targets module %q but no matching .so was found in %s; no symbols injected", symbolsTarget, dir)
+	}
 	log.Printf("[+] Fixed %d .so file(s)", count)
 	return nil
+}
+
+// soMatchesModule reports whether a dumped .so file belongs to module stem.
+// dumpso names files so_<pid>_<base>_<size>_<stem>.so, and JNI symbol maps are
+// jni_symbols_<stem>.txt, so the stems are compared after sanitizing; a plain
+// <stem>.so (a user-renamed file) matches too.
+func soMatchesModule(soFileName, stem string) bool {
+	base := sanitizeSoName(soFileName)
+	return base == stem || strings.HasSuffix(base, "_"+stem)
 }
 
 // parseSymbolFile reads an "offset name" map (one entry per line, blank lines
@@ -161,7 +191,7 @@ func parseSymbolFile(path string) ([]InjectedSym, error) {
 		return nil, err
 	}
 	var syms []InjectedSym
-	for _, line := range strings.Split(string(data), "\n") {
+	for lineNo, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -170,11 +200,26 @@ func parseSymbolFile(path string) ([]InjectedSym, error) {
 		if len(fields) < 2 {
 			continue
 		}
-		off, err := strconv.ParseUint(strings.TrimPrefix(fields[0], "0x"), 16, 64)
+		hexStr := strings.TrimPrefix(strings.TrimPrefix(fields[0], "0x"), "0X")
+		off, err := strconv.ParseUint(hexStr, 16, 64)
 		if err != nil {
+			log.Printf("[!] symbols %s:%d: skipping line, bad hex offset %q", filepath.Base(path), lineNo+1, fields[0])
 			continue
 		}
 		syms = append(syms, InjectedSym{Name: fields[1], Value: off})
 	}
 	return syms, nil
+}
+
+// moduleStemFromSymbolsFile extracts the module stem from a JNI symbols file
+// named jni_symbols_<stem>.txt (as written by the dump stage), so fixso can
+// inject those symbols only into the matching .so. Returns "" for any other
+// filename, letting the caller fall back to injecting into every library.
+func moduleStemFromSymbolsFile(path string) string {
+	base := filepath.Base(path)
+	const prefix = "jni_symbols_"
+	if !strings.HasPrefix(base, prefix) || !strings.HasSuffix(base, ".txt") {
+		return ""
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(base, prefix), ".txt")
 }

--- a/fix_so.go
+++ b/fix_so.go
@@ -1,0 +1,131 @@
+//go:build arm64
+
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	elf64HeaderSize = 64
+	elf64PhdrSize   = 56
+	ptLoad          = 1
+)
+
+// FixOneSo repairs a raw memory dump of a native library so static analysis
+// tools (IDA/Ghidra/objdump) can load it. A dump built from /proc/<pid>/maps
+// places each segment's bytes at (vaddr - moduleBase) in the output buffer,
+// which does not match the on-disk file layout the original ELF header
+// describes, so two things are patched for every PT_LOAD segment:
+//   - p_offset is rewritten to equal p_vaddr, matching how the dump was laid out
+//   - p_filesz is raised to p_memsz, since the memory image already contains
+//     the segment's full size (e.g. the zero-filled .bss tail)
+//
+// The section header table is never patched in place: it lives outside every
+// PT_LOAD segment (the loader has no reason to map it), so it was never part
+// of the memory dump. e_shoff/e_shnum/e_shstrndx are zeroed instead of left
+// pointing at stale offsets copied from the live header.
+func FixOneSo(soPath, outPath string) error {
+	data, err := os.ReadFile(soPath)
+	if err != nil {
+		return fmt.Errorf("read so: %w", err)
+	}
+
+	if len(data) < elf64HeaderSize || !bytes.Equal(data[:4], []byte{0x7f, 'E', 'L', 'F'}) {
+		return fmt.Errorf("not a valid ELF file")
+	}
+	if data[4] != 2 {
+		return fmt.Errorf("only ELF64 is supported (EI_CLASS=%d)", data[4])
+	}
+
+	phoff := binary.LittleEndian.Uint64(data[32:40])
+	phentsize := binary.LittleEndian.Uint16(data[54:56])
+	phnum := binary.LittleEndian.Uint16(data[56:58])
+	if phoff == 0 || phnum == 0 {
+		return fmt.Errorf("no program headers")
+	}
+
+	var fixed int
+	for i := 0; i < int(phnum); i++ {
+		off := int(phoff) + i*int(phentsize)
+		if off+elf64PhdrSize > len(data) {
+			break
+		}
+		if binary.LittleEndian.Uint32(data[off:off+4]) != ptLoad {
+			continue
+		}
+
+		vaddr := binary.LittleEndian.Uint64(data[off+16 : off+24])
+		filesz := binary.LittleEndian.Uint64(data[off+32 : off+40])
+		memsz := binary.LittleEndian.Uint64(data[off+40 : off+48])
+
+		binary.LittleEndian.PutUint64(data[off+8:off+16], vaddr)
+		if memsz > filesz {
+			binary.LittleEndian.PutUint64(data[off+32:off+40], memsz)
+		}
+		fixed++
+	}
+
+	if fixed == 0 {
+		return fmt.Errorf("no PT_LOAD segments found")
+	}
+
+	binary.LittleEndian.PutUint64(data[40:48], 0) // e_shoff
+	binary.LittleEndian.PutUint16(data[60:62], 0) // e_shnum
+	binary.LittleEndian.PutUint16(data[62:64], 0) // e_shstrndx
+
+	if err := os.WriteFile(outPath, data, 0644); err != nil {
+		return fmt.Errorf("write out: %w", err)
+	}
+	return nil
+}
+
+// FixSoDirectory scans dir for dumped .so files and writes fixed copies to
+// a "fix" subdirectory, mirroring FixDexDirectory's layout.
+func FixSoDirectory(dir string) error {
+	fixDir := filepath.Join(dir, "fix")
+	if err := os.MkdirAll(fixDir, 0755); err != nil {
+		return fmt.Errorf("failed to create fix dir %s: %w", fixDir, err)
+	}
+
+	var count int
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path == fixDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".so") {
+			return nil
+		}
+
+		outPath := filepath.Join(fixDir, strings.TrimSuffix(name, ".so")+"_fix.so")
+		if err := FixOneSo(path, outPath); err != nil {
+			fmt.Fprintf(os.Stdout, "[!] Fix failed for %s: %v\n", path, err)
+			return nil
+		}
+		fmt.Fprintf(os.Stdout, "[+] Wrote %s\n", outPath)
+		count++
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return fmt.Errorf("no .so files found in %s", dir)
+	}
+	log.Printf("[+] Fixed %d .so file(s)", count)
+	return nil
+}

--- a/fix_so.go
+++ b/fix_so.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"io/fs"
 	"log"
@@ -13,11 +12,9 @@ import (
 	"strings"
 )
 
-const (
-	elf64HeaderSize = 64
-	elf64PhdrSize   = 56
-	ptLoad          = 1
-)
+// ptLoad is the PT_LOAD program-header type. The remaining ELF constants and
+// the elfLayout helper live in so_rebuild.go (same package).
+const ptLoad = 1
 
 // FixOneSo repairs a raw memory dump of a native library so static analysis
 // tools (IDA/Ghidra/objdump) can load it. A dump built from /proc/<pid>/maps
@@ -38,11 +35,11 @@ func FixOneSo(soPath, outPath string) error {
 		return fmt.Errorf("read so: %w", err)
 	}
 
-	if len(data) < elf64HeaderSize || !bytes.Equal(data[:4], []byte{0x7f, 'E', 'L', 'F'}) {
+	if len(data) < 16 || !bytes.Equal(data[:4], []byte{0x7f, 'E', 'L', 'F'}) {
 		return fmt.Errorf("not a valid ELF file")
 	}
-	if data[4] != 2 {
-		return fmt.Errorf("only ELF64 is supported (EI_CLASS=%d)", data[4])
+	if data[4] != 1 && data[4] != 2 {
+		return fmt.Errorf("unsupported EI_CLASS=%d (want ELF32 or ELF64)", data[4])
 	}
 
 	// Preferred path: rebuild the section header table from the dynamic segment.
@@ -50,36 +47,48 @@ func FixOneSo(soPath, outPath string) error {
 		if werr := os.WriteFile(outPath, rebuilt, 0644); werr != nil {
 			return fmt.Errorf("write out: %w", werr)
 		}
+		if n, cerr := SelfCheckSo(rebuilt); cerr == nil {
+			log.Printf("[fixso] %s: rebuilt section headers, %d dynamic symbols readable", filepath.Base(outPath), n)
+		} else {
+			log.Printf("[fixso] %s: rebuilt section headers, but self-check couldn't read symbols: %v", filepath.Base(outPath), cerr)
+		}
 		return nil
 	} else {
 		log.Printf("[fixso] section rebuild unavailable for %s (%v); falling back to header-only fix", filepath.Base(soPath), rerr)
 	}
 
-	// Fallback: normalize p_offset and zero out the section header table.
-	phoff := binary.LittleEndian.Uint64(data[32:40])
-	phentsize := binary.LittleEndian.Uint16(data[54:56])
-	phnum := binary.LittleEndian.Uint16(data[56:58])
+	// Fallback: normalize p_offset and zero out the section header table,
+	// class-aware so both ELF32 and ELF64 dumps still load via program headers.
+	l := elfLayout{is64: data[4] == 2}
+	if len(data) < l.ehdrSize() {
+		return fmt.Errorf("truncated ELF header")
+	}
+	phoff := l.phoff(data)
+	phentsize := l.phentsize(data)
+	phnum := l.phnum(data)
+	if phentsize == 0 {
+		phentsize = l.phdrSize()
+	}
 	if phoff == 0 || phnum == 0 {
 		return fmt.Errorf("no program headers")
 	}
 
 	var fixed int
-	for i := 0; i < int(phnum); i++ {
-		off := int(phoff) + i*int(phentsize)
-		if off+elf64PhdrSize > len(data) {
+	for i := 0; i < phnum; i++ {
+		off := int(phoff) + i*phentsize
+		if off+l.phdrSize() > len(data) {
 			break
 		}
-		if binary.LittleEndian.Uint32(data[off:off+4]) != ptLoad {
+		ph := data[off:]
+		if l.pType(ph) != ptLoad {
 			continue
 		}
-
-		vaddr := binary.LittleEndian.Uint64(data[off+16 : off+24])
-		filesz := binary.LittleEndian.Uint64(data[off+32 : off+40])
-		memsz := binary.LittleEndian.Uint64(data[off+40 : off+48])
-
-		binary.LittleEndian.PutUint64(data[off+8:off+16], vaddr)
+		vaddr := l.pVaddr(ph)
+		filesz := l.pFilesz(ph)
+		memsz := l.pMemsz(ph)
+		l.setPOffset(ph, vaddr)
 		if memsz > filesz {
-			binary.LittleEndian.PutUint64(data[off+32:off+40], memsz)
+			l.setPFilesz(ph, memsz)
 		}
 		fixed++
 	}
@@ -88,9 +97,9 @@ func FixOneSo(soPath, outPath string) error {
 		return fmt.Errorf("no PT_LOAD segments found")
 	}
 
-	binary.LittleEndian.PutUint64(data[40:48], 0) // e_shoff
-	binary.LittleEndian.PutUint16(data[60:62], 0) // e_shnum
-	binary.LittleEndian.PutUint16(data[62:64], 0) // e_shstrndx
+	l.setShoff(data, 0)
+	l.setShnum(data, 0)
+	l.setShstrndx(data, 0)
 
 	if err := os.WriteFile(outPath, data, 0644); err != nil {
 		return fmt.Errorf("write out: %w", err)

--- a/fix_so.go
+++ b/fix_so.go
@@ -23,15 +23,15 @@ const (
 // tools (IDA/Ghidra/objdump) can load it. A dump built from /proc/<pid>/maps
 // places each segment's bytes at (vaddr - moduleBase) in the output buffer,
 // which does not match the on-disk file layout the original ELF header
-// describes, so two things are patched for every PT_LOAD segment:
-//   - p_offset is rewritten to equal p_vaddr, matching how the dump was laid out
-//   - p_filesz is raised to p_memsz, since the memory image already contains
-//     the segment's full size (e.g. the zero-filled .bss tail)
+// describes.
 //
-// The section header table is never patched in place: it lives outside every
-// PT_LOAD segment (the loader has no reason to map it), so it was never part
-// of the memory dump. e_shoff/e_shnum/e_shstrndx are zeroed instead of left
-// pointing at stale offsets copied from the live header.
+// The preferred fix reconstructs a full section header table from the dynamic
+// segment (see RebuildSoSections), which restores .dynsym/.dynstr, relocation,
+// hash and version sections so IDA recognizes symbols, imports and relocations.
+// If that can't run (e.g. no PT_DYNAMIC), it falls back to a minimal fix: patch
+// every PT_LOAD segment's p_offset to equal p_vaddr and p_filesz up to p_memsz,
+// then zero the section header table (which was never part of the memory image)
+// so tools at least load the file via its program headers.
 func FixOneSo(soPath, outPath string) error {
 	data, err := os.ReadFile(soPath)
 	if err != nil {
@@ -45,6 +45,17 @@ func FixOneSo(soPath, outPath string) error {
 		return fmt.Errorf("only ELF64 is supported (EI_CLASS=%d)", data[4])
 	}
 
+	// Preferred path: rebuild the section header table from the dynamic segment.
+	if rebuilt, rerr := RebuildSoSections(data); rerr == nil {
+		if werr := os.WriteFile(outPath, rebuilt, 0644); werr != nil {
+			return fmt.Errorf("write out: %w", werr)
+		}
+		return nil
+	} else {
+		log.Printf("[fixso] section rebuild unavailable for %s (%v); falling back to header-only fix", filepath.Base(soPath), rerr)
+	}
+
+	// Fallback: normalize p_offset and zero out the section header table.
 	phoff := binary.LittleEndian.Uint64(data[32:40])
 	phentsize := binary.LittleEndian.Uint16(data[54:56])
 	phnum := binary.LittleEndian.Uint16(data[56:58])

--- a/fix_so.go
+++ b/fix_so.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -29,7 +30,7 @@ const ptLoad = 1
 // every PT_LOAD segment's p_offset to equal p_vaddr and p_filesz up to p_memsz,
 // then zero the section header table (which was never part of the memory image)
 // so tools at least load the file via its program headers.
-func FixOneSo(soPath, outPath string) error {
+func FixOneSo(soPath, outPath string, injected []InjectedSym) error {
 	data, err := os.ReadFile(soPath)
 	if err != nil {
 		return fmt.Errorf("read so: %w", err)
@@ -43,7 +44,7 @@ func FixOneSo(soPath, outPath string) error {
 	}
 
 	// Preferred path: rebuild the section header table from the dynamic segment.
-	if rebuilt, rerr := RebuildSoSections(data); rerr == nil {
+	if rebuilt, rerr := RebuildSoSections(data, injected); rerr == nil {
 		if werr := os.WriteFile(outPath, rebuilt, 0644); werr != nil {
 			return fmt.Errorf("write out: %w", werr)
 		}
@@ -109,7 +110,7 @@ func FixOneSo(soPath, outPath string) error {
 
 // FixSoDirectory scans dir for dumped .so files and writes fixed copies to
 // a "fix" subdirectory, mirroring FixDexDirectory's layout.
-func FixSoDirectory(dir string) error {
+func FixSoDirectory(dir string, injected []InjectedSym) error {
 	fixDir := filepath.Join(dir, "fix")
 	if err := os.MkdirAll(fixDir, 0755); err != nil {
 		return fmt.Errorf("failed to create fix dir %s: %w", fixDir, err)
@@ -132,7 +133,7 @@ func FixSoDirectory(dir string) error {
 		}
 
 		outPath := filepath.Join(fixDir, strings.TrimSuffix(name, ".so")+"_fix.so")
-		if err := FixOneSo(path, outPath); err != nil {
+		if err := FixOneSo(path, outPath, injected); err != nil {
 			fmt.Fprintf(os.Stdout, "[!] Fix failed for %s: %v\n", path, err)
 			return nil
 		}
@@ -148,4 +149,32 @@ func FixSoDirectory(dir string) error {
 	}
 	log.Printf("[+] Fixed %d .so file(s)", count)
 	return nil
+}
+
+// parseSymbolFile reads an "offset name" map (one entry per line, blank lines
+// and '#' comments ignored) for fixso --symbols. The offset is a hex module
+// offset (with or without a 0x prefix); everything after it up to whitespace is
+// the symbol name. Typically produced by the JNI RegisterNatives capture.
+func parseSymbolFile(path string) ([]InjectedSym, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var syms []InjectedSym
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		off, err := strconv.ParseUint(strings.TrimPrefix(fields[0], "0x"), 16, 64)
+		if err != nil {
+			continue
+		}
+		syms = append(syms, InjectedSym{Name: fields[1], Value: off})
+	}
+	return syms, nil
 }

--- a/header.h
+++ b/header.h
@@ -46,9 +46,21 @@ struct method_event_data_t {
 // Event for notifying read failures - go should use readRemoteMem
 struct dex_read_failure_t {
     u64 begin;       // failed dex begin address
-    u32 pid;         // target pid  
+    u32 pid;         // target pid
     u32 size;        // total dex size
     u32 failed_offset; // offset where read failed
+};
+
+// One event per JNI native method seen at RegisterNatives. Go maps fn_ptr back
+// to a module offset and injects `name` as a .symtab symbol via fixso, so
+// dynamically-registered JNI functions show real names in IDA.
+#define JNI_NAME_MAX 96
+#define JNI_SIG_MAX  96
+struct jni_method_event_t {
+    u32 pid;
+    u64 fn_ptr;               // runtime address of the native function
+    char name[JNI_NAME_MAX];  // Java method name
+    char sig[JNI_SIG_MAX];    // JNI type signature
 };
 
 typedef struct simple_buf {
@@ -81,6 +93,12 @@ struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 20);
 } read_failures SEC(".maps");
+
+// Ring buffer for JNI RegisterNatives captures
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 20);
+} jni_events SEC(".maps");
 
 // Config map
 struct

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	app := &cli.App{
 		Name:  "eBPFDexDumper",
-		Usage: "Dump in-memory DEX and method bytecode or fix dumped DEX files",
+		Usage: "Dump in-memory DEX/method bytecode or native .so libraries, and fix the dumped files",
 		// Custom help template shows concise top-level info and compact subcommand details
 		CustomAppHelpTemplate: `NAME:
    {{.Name}} - {{.Usage}}
@@ -167,6 +167,112 @@ OPTIONS:
 					outDir := c.String("dir")
 					if err := FixDexDirectory(outDir); err != nil {
 						return fmt.Errorf("fix dex failed: %w", err)
+					}
+					log.Printf("Fix completed for directory: %s", outDir)
+					return nil
+				},
+			},
+			{
+				Name:        "dumpso",
+				Usage:       "Dump native .so libraries from a running process's memory",
+				Description: "Scan /proc/<pid>/maps for loaded shared libraries (plus optionally self-mapped anonymous ELF images), read their full mapped span from process memory, and write raw dumps; provide either --uid or --name to select the target process(es).",
+				CustomHelpTemplate: `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} [command options]
+
+DESCRIPTION:
+   {{.Description}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}`,
+				Flags: []cli.Flag{
+					&cli.Uint64Flag{Name: "uid", Aliases: []string{"u"}, Usage: "Filter by UID (alternative to --name)"},
+					&cli.StringFlag{Name: "name", Aliases: []string{"n"}, Usage: "Android package name to derive UID (alternative to --uid)"},
+					&cli.StringFlag{Name: "lib", Aliases: []string{"l"}, Usage: "Only dump libraries whose path contains this substring (default: all app-mapped .so files)"},
+					&cli.StringFlag{Name: "out", Aliases: []string{"o", "output"}, Usage: "Output directory on device", Value: "/data/local/tmp/so_out", DefaultText: "/data/local/tmp/so_out"},
+					&cli.BoolFlag{Name: "anon", Aliases: []string{"a"}, Usage: "Also scan anonymous memory regions for self-mapped ELF images", Value: true},
+					&cli.BoolFlag{Name: "auto-fix", Aliases: []string{"f"}, Usage: "Automatically fix dumped .so files after dumping", Value: true},
+					&cli.BoolFlag{Name: "no-anon", Usage: "Disable anonymous ELF region scanning"},
+					&cli.BoolFlag{Name: "no-auto-fix", Usage: "Disable automatic .so fixing"},
+				},
+				Action: func(c *cli.Context) error {
+					uid := uint32(c.Uint64("uid"))
+					pkgName := c.String("name")
+					libFilter := c.String("lib")
+					outputDir := c.String("out")
+					includeAnon := c.Bool("anon") && !c.Bool("no-anon")
+					autoFix := c.Bool("auto-fix") && !c.Bool("no-auto-fix")
+
+					if err := os.MkdirAll(outputDir, 0755); err != nil {
+						return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
+					}
+
+					if uid == 0 && pkgName == "" {
+						return fmt.Errorf("either --uid or --name must be provided")
+					}
+					if uid == 0 && pkgName != "" {
+						resolved, err := LookupUIDByPackageName(pkgName)
+						if err != nil {
+							return err
+						}
+						uid = resolved
+						log.Printf("[+] Resolved UID %d from package %q", uid, pkgName)
+					}
+
+					pids, err := FindPidsForUID(uid)
+					if err != nil {
+						return err
+					}
+					log.Printf("[+] Found %d process(es) for uid %d: %v", len(pids), uid, pids)
+
+					var dumped []string
+					for _, pid := range pids {
+						mods, err := ScanSoModules(pid, libFilter, includeAnon)
+						if err != nil {
+							log.Printf("[!] scan failed for pid %d: %v", pid, err)
+							continue
+						}
+						log.Printf("[+] pid %d: found %d candidate module(s)", pid, len(mods))
+						dumped = append(dumped, DumpSoModules(pid, mods, outputDir)...)
+					}
+
+					if autoFix && len(dumped) > 0 {
+						log.Printf("[+] Auto-fixing dumped .so files...")
+						if err := FixSoDirectory(outputDir); err != nil {
+							log.Printf("[!] Auto-fix failed: %v", err)
+						}
+					}
+
+					log.Printf("[+] Done. Dumped %d .so file(s) to %s", len(dumped), outputDir)
+					return nil
+				},
+			},
+			{
+				Name:        "fixso",
+				Usage:       "Fix dumped .so files in a directory",
+				Description: "Scan a directory for dumped .so files and rewrite segment headers for static analysis tools.",
+				CustomHelpTemplate: `NAME:
+   {{.HelpName}} - {{.Usage}}
+
+USAGE:
+   {{.HelpName}} [command options]
+
+DESCRIPTION:
+   {{.Description}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}`,
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "dir", Aliases: []string{"d"}, Usage: "Directory containing dumped .so files", Required: true},
+				},
+				Action: func(c *cli.Context) error {
+					outDir := c.String("dir")
+					if err := FixSoDirectory(outDir); err != nil {
+						return fmt.Errorf("fix so failed: %w", err)
 					}
 					log.Printf("Fix completed for directory: %s", outDir)
 					return nil

--- a/main.go
+++ b/main.go
@@ -233,17 +233,24 @@ OPTIONS:
 
 					var dumped []string
 					if watch {
-						ctx, cancel := context.WithCancel(context.Background())
+						var ctx context.Context
+						var cancel context.CancelFunc
 						if watchTimeout > 0 {
 							ctx, cancel = context.WithTimeout(context.Background(), time.Duration(watchTimeout)*time.Second)
+						} else {
+							ctx, cancel = context.WithCancel(context.Background())
 						}
 						defer cancel()
 
 						sigChan := make(chan os.Signal, 1)
 						signal.Notify(sigChan, os.Interrupt, unix.SIGTERM)
+						defer signal.Stop(sigChan)
 						go func() {
-							<-sigChan
-							cancel()
+							select {
+							case <-sigChan:
+								cancel()
+							case <-ctx.Done():
+							}
 						}()
 
 						log.Printf("[+] Watching uid %d every %ds (timeout %ds; Ctrl-C to stop)...", uid, watchInterval, watchTimeout)
@@ -268,7 +275,7 @@ OPTIONS:
 
 					if autoFix && len(dumped) > 0 {
 						log.Printf("[+] Auto-fixing dumped .so files...")
-						if err := FixSoDirectory(outputDir, nil); err != nil {
+						if err := FixSoDirectory(outputDir, nil, ""); err != nil {
 							log.Printf("[!] Auto-fix failed: %v", err)
 						}
 					}
@@ -300,15 +307,21 @@ OPTIONS:
 				Action: func(c *cli.Context) error {
 					outDir := c.String("dir")
 					var injected []InjectedSym
+					var symbolsTarget string
 					if sf := c.String("symbols"); sf != "" {
 						syms, err := parseSymbolFile(sf)
 						if err != nil {
 							return fmt.Errorf("read symbols file: %w", err)
 						}
 						injected = syms
-						log.Printf("[+] Loaded %d symbol(s) to inject from %s", len(injected), sf)
+						symbolsTarget = moduleStemFromSymbolsFile(sf)
+						if symbolsTarget != "" {
+							log.Printf("[+] Loaded %d symbol(s) from %s (target module %q)", len(injected), sf, symbolsTarget)
+						} else {
+							log.Printf("[+] Loaded %d symbol(s) from %s; couldn't infer target module, will inject into every .so", len(injected), sf)
+						}
 					}
-					if err := FixSoDirectory(outDir, injected); err != nil {
+					if err := FixSoDirectory(outDir, injected, symbolsTarget); err != nil {
 						return fmt.Errorf("fix so failed: %w", err)
 					}
 					log.Printf("Fix completed for directory: %s", outDir)

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	cli "github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
@@ -197,6 +198,10 @@ OPTIONS:
 					&cli.BoolFlag{Name: "auto-fix", Aliases: []string{"f"}, Usage: "Automatically fix dumped .so files after dumping", Value: true},
 					&cli.BoolFlag{Name: "no-anon", Usage: "Disable anonymous ELF region scanning"},
 					&cli.BoolFlag{Name: "no-auto-fix", Usage: "Disable automatic .so fixing"},
+					&cli.BoolFlag{Name: "include-system", Usage: "Also dump system libraries under /system, /apex, /vendor (default: skip them)"},
+					&cli.BoolFlag{Name: "watch", Aliases: []string{"w"}, Usage: "Keep watching the process and dump modules as they appear (captures runtime-decrypted libs)"},
+					&cli.Uint64Flag{Name: "watch-interval", Usage: "Seconds between map re-scans in --watch mode", Value: 1},
+					&cli.Uint64Flag{Name: "watch-timeout", Usage: "Stop --watch after N seconds (0 = until interrupted)", Value: 60},
 				},
 				Action: func(c *cli.Context) error {
 					uid := uint32(c.Uint64("uid"))
@@ -205,6 +210,10 @@ OPTIONS:
 					outputDir := c.String("out")
 					includeAnon := c.Bool("anon") && !c.Bool("no-anon")
 					autoFix := c.Bool("auto-fix") && !c.Bool("no-auto-fix")
+					includeSystem := c.Bool("include-system")
+					watch := c.Bool("watch")
+					watchInterval := c.Uint64("watch-interval")
+					watchTimeout := c.Uint64("watch-timeout")
 
 					if err := os.MkdirAll(outputDir, 0755); err != nil {
 						return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
@@ -222,21 +231,39 @@ OPTIONS:
 						log.Printf("[+] Resolved UID %d from package %q", uid, pkgName)
 					}
 
-					pids, err := FindPidsForUID(uid)
-					if err != nil {
-						return err
-					}
-					log.Printf("[+] Found %d process(es) for uid %d: %v", len(pids), uid, pids)
-
 					var dumped []string
-					for _, pid := range pids {
-						mods, err := ScanSoModules(pid, libFilter, includeAnon)
-						if err != nil {
-							log.Printf("[!] scan failed for pid %d: %v", pid, err)
-							continue
+					if watch {
+						ctx, cancel := context.WithCancel(context.Background())
+						if watchTimeout > 0 {
+							ctx, cancel = context.WithTimeout(context.Background(), time.Duration(watchTimeout)*time.Second)
 						}
-						log.Printf("[+] pid %d: found %d candidate module(s)", pid, len(mods))
-						dumped = append(dumped, DumpSoModules(pid, mods, outputDir)...)
+						defer cancel()
+
+						sigChan := make(chan os.Signal, 1)
+						signal.Notify(sigChan, os.Interrupt, unix.SIGTERM)
+						go func() {
+							<-sigChan
+							cancel()
+						}()
+
+						log.Printf("[+] Watching uid %d every %ds (timeout %ds; Ctrl-C to stop)...", uid, watchInterval, watchTimeout)
+						dumped = WatchAndDump(ctx, uid, libFilter, includeAnon, includeSystem, outputDir, time.Duration(watchInterval)*time.Second)
+					} else {
+						pids, err := FindPidsForUID(uid)
+						if err != nil {
+							return err
+						}
+						log.Printf("[+] Found %d process(es) for uid %d: %v", len(pids), uid, pids)
+
+						for _, pid := range pids {
+							mods, err := ScanSoModules(pid, libFilter, includeAnon, includeSystem)
+							if err != nil {
+								log.Printf("[!] scan failed for pid %d: %v", pid, err)
+								continue
+							}
+							log.Printf("[+] pid %d: found %d candidate module(s)", pid, len(mods))
+							dumped = append(dumped, DumpSoModules(pid, mods, outputDir)...)
+						}
 					}
 
 					if autoFix && len(dumped) > 0 {

--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ OPTIONS:
 
 					if autoFix && len(dumped) > 0 {
 						log.Printf("[+] Auto-fixing dumped .so files...")
-						if err := FixSoDirectory(outputDir); err != nil {
+						if err := FixSoDirectory(outputDir, nil); err != nil {
 							log.Printf("[!] Auto-fix failed: %v", err)
 						}
 					}
@@ -295,10 +295,20 @@ OPTIONS:
    {{end}}`,
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "dir", Aliases: []string{"d"}, Usage: "Directory containing dumped .so files", Required: true},
+					&cli.StringFlag{Name: "symbols", Aliases: []string{"s"}, Usage: "File of 'offset name' lines to inject as .symtab symbols (e.g. recovered JNI functions)"},
 				},
 				Action: func(c *cli.Context) error {
 					outDir := c.String("dir")
-					if err := FixSoDirectory(outDir); err != nil {
+					var injected []InjectedSym
+					if sf := c.String("symbols"); sf != "" {
+						syms, err := parseSymbolFile(sf)
+						if err != nil {
+							return fmt.Errorf("read symbols file: %w", err)
+						}
+						injected = syms
+						log.Printf("[+] Loaded %d symbol(s) to inject from %s", len(injected), sf)
+					}
+					if err := FixSoDirectory(outDir, injected); err != nil {
 						return fmt.Errorf("fix so failed: %w", err)
 					}
 					log.Printf("Fix completed for directory: %s", outDir)

--- a/so_dumper.go
+++ b/so_dumper.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"hash/fnv"
 	"log"
 	"os"
 	"path/filepath"
@@ -318,19 +319,36 @@ func DumpSoModules(pid int, mods []soModule, outDir string) []string {
 	return written
 }
 
+// watchMaxRedumps caps how many times a single (pid, base, end) region is
+// re-dumped when its contents change, so an app that keeps writing to a mapping
+// can't drive the watcher into an unbounded re-dump loop.
+const watchMaxRedumps = 3
+
+// modWatchState tracks a region across scans: fp is a cheap fingerprint of a few
+// sampled windows, dumps is how many times it's been captured so far.
+type modWatchState struct {
+	fp    uint64
+	dumps int
+}
+
 // WatchAndDump polls the target uid's processes and dumps each newly appearing
 // module the moment it shows up, until ctx is cancelled. This captures
 // runtime-decrypted / self-mapped .so images right after a packer maps them,
 // without having to know the decrypt routine's address: a freshly decrypted
 // library surfaces as a new anonymous ELF region (or a newly loaded file) that
 // wasn't there on the previous scan. interval bounds how often maps are
-// re-scanned; each module is dumped at most once per (pid, base, end).
+// re-scanned.
+//
+// A region is dumped on first appearance and re-dumped (overwriting the earlier
+// file) whenever its sampled contents change, up to watchMaxRedumps times. This
+// catches packers that map a region and only then decrypt it in place — keying
+// on (pid, base, end) alone would freeze the too-early, still-encrypted capture.
 func WatchAndDump(ctx context.Context, uid uint32, libFilter string, includeAnon, includeSystem bool, outDir string, interval time.Duration) []string {
 	if interval <= 0 {
 		interval = time.Second
 	}
 	var written []string
-	seen := map[string]bool{}
+	seen := map[string]modWatchState{}
 
 	scan := func() {
 		pids, err := FindPidsForUID(uid)
@@ -345,14 +363,19 @@ func WatchAndDump(ctx context.Context, uid uint32, libFilter string, includeAnon
 			var fresh []soModule
 			for _, m := range mods {
 				key := fmt.Sprintf("%d_%x_%x", pid, m.Base, m.End)
-				if seen[key] {
-					continue
+				st, ok := seen[key]
+				if ok && st.dumps >= watchMaxRedumps {
+					continue // settled: stop re-reading it
 				}
-				seen[key] = true
+				fp := moduleFingerprint(pid, m)
+				if ok && st.fp == fp {
+					continue // unchanged since the last capture
+				}
+				seen[key] = modWatchState{fp: fp, dumps: st.dumps + 1}
 				fresh = append(fresh, m)
 			}
 			if len(fresh) > 0 {
-				log.Printf("[so-watch] pid %d: %d new module(s) appeared", pid, len(fresh))
+				log.Printf("[so-watch] pid %d: %d new/changed module(s)", pid, len(fresh))
 				written = append(written, DumpSoModules(pid, fresh, outDir)...)
 			}
 		}
@@ -369,4 +392,24 @@ func WatchAndDump(ctx context.Context, uid uint32, libFilter string, includeAnon
 			scan()
 		}
 	}
+}
+
+// moduleFingerprint samples a few small windows across a module's mapped span
+// and returns an FNV-1a hash of them. It is cheap enough to run on every scan
+// and changes when a packer rewrites code in place (e.g. decrypts .text), which
+// is what tells WatchAndDump to re-dump. Unreadable windows are skipped.
+func moduleFingerprint(pid int, m soModule) uint64 {
+	span := m.End - m.Base
+	if span == 0 {
+		return 0
+	}
+	h := fnv.New64a()
+	var win [256]byte
+	for _, frac := range []uint64{0, span / 4, span / 2, (span * 3) / 4} {
+		n := C.readRemoteAddr(C.pid_t(pid), unsafe.Pointer(&win[0]), C.size_t(len(win)), C.uintptr_t(m.Base+frac))
+		if int(n) > 0 {
+			h.Write(win[:int(n)])
+		}
+	}
+	return h.Sum64()
 }

--- a/so_dumper.go
+++ b/so_dumper.go
@@ -1,0 +1,293 @@
+//go:build arm64
+
+package main
+
+/*
+#cgo CFLAGS: -D_GNU_SOURCE
+#include <sys/uio.h>
+#include <unistd.h>
+#include <stdint.h>
+
+// src is a remote address taken as a plain integer, not void*: Go's cgo
+// pointer checks inspect every unsafe.Pointer argument at call time and, if
+// its bit pattern happens to land inside a span this process's own Go heap
+// owns, walk it as if it were real Go memory - which panics. A target
+// process's address has no relation to our heap, but the check is a dynamic
+// numeric coincidence check, not a type-based one, so it can still fire.
+// Typing this parameter uintptr_t keeps it out of that check entirely.
+static ssize_t readRemoteAddr(pid_t pid, void *dst, size_t len, uintptr_t src) {
+    struct iovec local_iov = { dst, len };
+    struct iovec remote_iov = { (void *)src, len };
+    return process_vm_readv(pid, &local_iov, 1, &remote_iov, 1, 0);
+}
+*/
+import "C"
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"unsafe"
+)
+
+// Safety cap: refuse to allocate/dump a single module larger than this.
+const maxSoDumpSize = 512 * 1024 * 1024 // 512MB
+
+// soReadChunkSize is used to retry a failed whole-range read page by page,
+// so a single unreadable guard page doesn't sacrifice an entire dump.
+const soReadChunkSize = 4096
+
+// soModule describes one candidate native image to dump: either a
+// file-backed shared library (spanning all of its mapped segments) or an
+// anonymous, self-mapped ELF image (loaders/packers that don't go through
+// the normal linker path still need a page starting with the ELF magic).
+type soModule struct {
+	Name string // library file name, or "anon_<base>" for self-mapped images
+	Path string // full path from /proc/<pid>/maps, empty for anonymous modules
+	Base uint64
+	End  uint64 // exclusive
+}
+
+type mapEntry struct {
+	start, end uint64
+	perms      string
+	path       string
+}
+
+var mapsLineRe = regexp.MustCompile(`^([0-9a-fA-F]+)-([0-9a-fA-F]+)\s+([rwxsp-]{4})\s+[0-9a-fA-F]+\s+\S+\s+\d+\s*(.*)$`)
+
+// matches bionic-style "libfoo.so" as well as glibc-style versioned sonames
+// like "libfoo.so.6" or "libfoo.so.1.2".
+var soSuffixRe = regexp.MustCompile(`\.so(\.[0-9]+)*$`)
+
+func parseMapEntries(content string) []mapEntry {
+	var entries []mapEntry
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		m := mapsLineRe.FindStringSubmatch(scanner.Text())
+		if m == nil {
+			continue
+		}
+		start, err1 := strconv.ParseUint(m[1], 16, 64)
+		end, err2 := strconv.ParseUint(m[2], 16, 64)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		entries = append(entries, mapEntry{start: start, end: end, perms: m[3], path: strings.TrimSpace(m[4])})
+	}
+	return entries
+}
+
+// groupSoModules turns raw /proc/<pid>/maps entries into dumpable modules:
+//   - file-backed ".so" mappings are merged by path into one [minStart,maxEnd)
+//     span, since the loader maps each PT_LOAD segment of the same file
+//     separately (r--/r-x/rw-) but reserves the whole span contiguously
+//   - when includeAnon is set, runs of path-less (anonymous) VMAs whose first
+//     mapped page starts with the ELF magic are merged the same way; this
+//     catches packers that map/decrypt a library manually instead of going
+//     through the dynamic linker
+//
+// A non-empty libFilter narrows file-backed modules to matching paths and,
+// since it can't match an anonymous region by name, implicitly disables
+// anonymous scanning (the caller asked for one specific library).
+func groupSoModules(entries []mapEntry, libFilter string, includeAnon bool, elfMagicAt func(addr uint64) bool) []soModule {
+	if libFilter != "" {
+		includeAnon = false
+	}
+
+	byPath := map[string]*soModule{}
+	var order []string
+
+	for _, e := range entries {
+		if e.path == "" || !soSuffixRe.MatchString(e.path) {
+			continue
+		}
+		if libFilter != "" && !strings.Contains(e.path, libFilter) {
+			continue
+		}
+		mod, ok := byPath[e.path]
+		if !ok {
+			mod = &soModule{Name: filepath.Base(e.path), Path: e.path, Base: e.start, End: e.end}
+			byPath[e.path] = mod
+			order = append(order, e.path)
+			continue
+		}
+		if e.start < mod.Base {
+			mod.Base = e.start
+		}
+		if e.end > mod.End {
+			mod.End = e.end
+		}
+	}
+
+	var mods []soModule
+	for _, p := range order {
+		mods = append(mods, *byPath[p])
+	}
+
+	if includeAnon {
+		for i := 0; i < len(entries); {
+			e := entries[i]
+			if e.path != "" || !strings.Contains(e.perms, "r") || !elfMagicAt(e.start) {
+				i++
+				continue
+			}
+			start, end := e.start, e.end
+			j := i + 1
+			for j < len(entries) && entries[j].path == "" && entries[j].start == end {
+				end = entries[j].end
+				j++
+			}
+			mods = append(mods, soModule{Name: fmt.Sprintf("anon_%x", start), Base: start, End: end})
+			i = j
+		}
+	}
+
+	return mods
+}
+
+// FindPidsForUID scans /proc for running processes owned by uid.
+func FindPidsForUID(uid uint32) ([]int, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("read /proc: %w", err)
+	}
+
+	var pids []int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if !strings.HasPrefix(line, "Uid:") {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				if u, err := strconv.ParseUint(fields[1], 10, 32); err == nil && uint32(u) == uid {
+					pids = append(pids, pid)
+				}
+			}
+			break
+		}
+	}
+
+	if len(pids) == 0 {
+		return nil, fmt.Errorf("no running process found for uid %d", uid)
+	}
+	return pids, nil
+}
+
+func peekIsElf(pid int, addr uint64) bool {
+	buf := make([]byte, 4)
+	n := C.readRemoteAddr(C.pid_t(pid), unsafe.Pointer(&buf[0]), C.size_t(len(buf)), C.uintptr_t(addr))
+	if int(n) != len(buf) {
+		return false
+	}
+	return bytes.Equal(buf, []byte{0x7f, 'E', 'L', 'F'})
+}
+
+// ScanSoModules lists candidate native-library modules mapped into pid.
+func ScanSoModules(pid int, libFilter string, includeAnon bool) ([]soModule, error) {
+	mapsPath := fmt.Sprintf("/proc/%d/maps", pid)
+	data, err := os.ReadFile(mapsPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", mapsPath, err)
+	}
+
+	entries := parseMapEntries(string(data))
+	elfMagicAt := func(addr uint64) bool { return peekIsElf(pid, addr) }
+	return groupSoModules(entries, libFilter, includeAnon, elfMagicAt), nil
+}
+
+// readRemoteRange reads len(buf) bytes at base in pid's memory. If the
+// whole-range read fails (a common symptom of a guard/unmapped page
+// somewhere inside an otherwise-contiguous module span), it falls back to
+// page-sized reads so an unreadable page only costs that page, not the
+// whole module. Returns the number of bytes actually populated in buf.
+func readRemoteRange(pid int, base uint64, buf []byte) int {
+	if len(buf) == 0 {
+		return 0
+	}
+
+	n := C.readRemoteAddr(C.pid_t(pid), unsafe.Pointer(&buf[0]), C.size_t(len(buf)), C.uintptr_t(base))
+	if int(n) == len(buf) {
+		return len(buf)
+	}
+
+	total := 0
+	for off := 0; off < len(buf); off += soReadChunkSize {
+		end := off + soReadChunkSize
+		if end > len(buf) {
+			end = len(buf)
+		}
+		chunk := buf[off:end]
+		cn := C.readRemoteAddr(C.pid_t(pid), unsafe.Pointer(&chunk[0]), C.size_t(len(chunk)), C.uintptr_t(base)+C.uintptr_t(off))
+		if int(cn) == len(chunk) {
+			total += len(chunk)
+		}
+	}
+	return total
+}
+
+func sanitizeSoName(name string) string {
+	name = strings.TrimSuffix(name, ".so")
+	var sb strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+			sb.WriteRune(r)
+		} else {
+			sb.WriteByte('_')
+		}
+	}
+	return sb.String()
+}
+
+// DumpSoModules reads each module's full mapped span from pid's memory and
+// writes it as a raw file under outDir. Returns the paths written.
+func DumpSoModules(pid int, mods []soModule, outDir string) []string {
+	var written []string
+	for _, m := range mods {
+		size := m.End - m.Base
+		if size == 0 {
+			continue
+		}
+		if size > maxSoDumpSize {
+			log.Printf("[so-dump] skip %s: size %d exceeds safety cap %d", m.Name, size, maxSoDumpSize)
+			continue
+		}
+
+		buf := make([]byte, size)
+		got := readRemoteRange(pid, m.Base, buf)
+		if got == 0 {
+			log.Printf("[so-dump] failed to read %s (pid=%d, 0x%x-0x%x)", m.Name, pid, m.Base, m.End)
+			continue
+		}
+		if uint64(got) < size {
+			log.Printf("[so-dump] partial read for %s: %d/%d bytes captured", m.Name, got, size)
+		}
+
+		fname := fmt.Sprintf("%s/so_%d_%x_%x_%s.so", outDir, pid, m.Base, size, sanitizeSoName(m.Name))
+		if err := os.WriteFile(fname, buf, 0644); err != nil {
+			log.Printf("[so-dump] write failed for %s: %v", fname, err)
+			continue
+		}
+		log.Printf("[so-dump] saved %s (size=%d)", fname, size)
+		written = append(written, fname)
+	}
+	return written
+}

--- a/so_dumper.go
+++ b/so_dumper.go
@@ -26,6 +26,7 @@ import "C"
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -33,6 +34,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 	"unsafe"
 )
 
@@ -66,6 +68,21 @@ var mapsLineRe = regexp.MustCompile(`^([0-9a-fA-F]+)-([0-9a-fA-F]+)\s+([rwxsp-]{
 // like "libfoo.so.6" or "libfoo.so.1.2".
 var soSuffixRe = regexp.MustCompile(`\.so(\.[0-9]+)*$`)
 
+// systemLibPrefixes are read-only firmware/partition mounts whose libraries
+// can be pulled straight off the device image, so dumping them from memory is
+// just noise. Anonymous (self-mapped) images are never matched here.
+var systemLibPrefixes = []string{"/system/", "/apex/", "/vendor/", "/system_ext/", "/product/", "/odm/"}
+
+// isSystemLibPath reports whether path lives on one of the firmware partitions.
+func isSystemLibPath(path string) bool {
+	for _, p := range systemLibPrefixes {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
+}
+
 func parseMapEntries(content string) []mapEntry {
 	var entries []mapEntry
 	scanner := bufio.NewScanner(strings.NewReader(content))
@@ -96,7 +113,13 @@ func parseMapEntries(content string) []mapEntry {
 // A non-empty libFilter narrows file-backed modules to matching paths and,
 // since it can't match an anonymous region by name, implicitly disables
 // anonymous scanning (the caller asked for one specific library).
-func groupSoModules(entries []mapEntry, libFilter string, includeAnon bool, elfMagicAt func(addr uint64) bool) []soModule {
+//
+// Unless includeSystem is set, file-backed libraries on the firmware
+// partitions (/system, /apex, ...) are skipped since they can be pulled off
+// the device image directly; a non-empty libFilter overrides this (the caller
+// named a specific library). Anonymous self-mapped images are never filtered
+// out this way.
+func groupSoModules(entries []mapEntry, libFilter string, includeAnon, includeSystem bool, elfMagicAt func(addr uint64) bool) []soModule {
 	if libFilter != "" {
 		includeAnon = false
 	}
@@ -109,6 +132,9 @@ func groupSoModules(entries []mapEntry, libFilter string, includeAnon bool, elfM
 			continue
 		}
 		if libFilter != "" && !strings.Contains(e.path, libFilter) {
+			continue
+		}
+		if libFilter == "" && !includeSystem && isSystemLibPath(e.path) {
 			continue
 		}
 		mod, ok := byPath[e.path]
@@ -202,7 +228,7 @@ func peekIsElf(pid int, addr uint64) bool {
 }
 
 // ScanSoModules lists candidate native-library modules mapped into pid.
-func ScanSoModules(pid int, libFilter string, includeAnon bool) ([]soModule, error) {
+func ScanSoModules(pid int, libFilter string, includeAnon, includeSystem bool) ([]soModule, error) {
 	mapsPath := fmt.Sprintf("/proc/%d/maps", pid)
 	data, err := os.ReadFile(mapsPath)
 	if err != nil {
@@ -211,7 +237,7 @@ func ScanSoModules(pid int, libFilter string, includeAnon bool) ([]soModule, err
 
 	entries := parseMapEntries(string(data))
 	elfMagicAt := func(addr uint64) bool { return peekIsElf(pid, addr) }
-	return groupSoModules(entries, libFilter, includeAnon, elfMagicAt), nil
+	return groupSoModules(entries, libFilter, includeAnon, includeSystem, elfMagicAt), nil
 }
 
 // readRemoteRange reads len(buf) bytes at base in pid's memory. If the
@@ -290,4 +316,57 @@ func DumpSoModules(pid int, mods []soModule, outDir string) []string {
 		written = append(written, fname)
 	}
 	return written
+}
+
+// WatchAndDump polls the target uid's processes and dumps each newly appearing
+// module the moment it shows up, until ctx is cancelled. This captures
+// runtime-decrypted / self-mapped .so images right after a packer maps them,
+// without having to know the decrypt routine's address: a freshly decrypted
+// library surfaces as a new anonymous ELF region (or a newly loaded file) that
+// wasn't there on the previous scan. interval bounds how often maps are
+// re-scanned; each module is dumped at most once per (pid, base, end).
+func WatchAndDump(ctx context.Context, uid uint32, libFilter string, includeAnon, includeSystem bool, outDir string, interval time.Duration) []string {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	var written []string
+	seen := map[string]bool{}
+
+	scan := func() {
+		pids, err := FindPidsForUID(uid)
+		if err != nil {
+			return // target may not have started yet; keep watching
+		}
+		for _, pid := range pids {
+			mods, err := ScanSoModules(pid, libFilter, includeAnon, includeSystem)
+			if err != nil {
+				continue
+			}
+			var fresh []soModule
+			for _, m := range mods {
+				key := fmt.Sprintf("%d_%x_%x", pid, m.Base, m.End)
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				fresh = append(fresh, m)
+			}
+			if len(fresh) > 0 {
+				log.Printf("[so-watch] pid %d: %d new module(s) appeared", pid, len(fresh))
+				written = append(written, DumpSoModules(pid, fresh, outDir)...)
+			}
+		}
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	scan() // capture whatever is already mapped immediately
+	for {
+		select {
+		case <-ctx.Done():
+			return written
+		case <-ticker.C:
+			scan()
+		}
+	}
 }

--- a/so_rebuild.go
+++ b/so_rebuild.go
@@ -3,16 +3,11 @@
 package main
 
 import (
+	"bytes"
+	"debug/elf"
 	"encoding/binary"
 	"fmt"
 	"sort"
-)
-
-// ELF64 structure sizes (elf64HeaderSize/elf64PhdrSize live in fix_so.go).
-const (
-	elf64ShdrSize = 64
-	elf64DynSize  = 16
-	elf64SymSize  = 24
 )
 
 // program header type (ptLoad lives in fix_so.go)
@@ -20,21 +15,25 @@ const ptDynamic = 2
 
 // section header types
 const (
-	shtNull       = 0
-	shtProgbits   = 1
-	shtStrtab     = 3
-	shtRela       = 4
-	shtHash       = 5
-	shtDynamic    = 6
-	shtNobits     = 8
-	shtDynsym     = 11
-	shtInitArray  = 14
-	shtFiniArray  = 15
-	shtRelr       = 19
-	shtGnuHash    = 0x6ffffff6
-	shtGnuVerdef  = 0x6ffffffd
-	shtGnuVerneed = 0x6ffffffe
-	shtGnuVersym  = 0x6fffffff
+	shtNull        = 0
+	shtProgbits    = 1
+	shtStrtab      = 3
+	shtRela        = 4
+	shtHash        = 5
+	shtDynamic     = 6
+	shtNobits      = 8
+	shtRel         = 9
+	shtDynsym      = 11
+	shtInitArray   = 14
+	shtFiniArray   = 15
+	shtRelr        = 19
+	shtAndroidRel  = 0x60000001
+	shtAndroidRela = 0x60000002
+	shtAndroidRelr = 0x6fffff00
+	shtGnuHash     = 0x6ffffff6
+	shtGnuVerdef   = 0x6ffffffd
+	shtGnuVerneed  = 0x6ffffffe
+	shtGnuVersym   = 0x6fffffff
 )
 
 // section header flags
@@ -47,34 +46,160 @@ const (
 
 // dynamic tags
 const (
-	dtNull        = 0
-	dtPltrelsz    = 2
-	dtPltgot      = 3
-	dtHash        = 4
-	dtStrtab      = 5
-	dtSymtab      = 6
-	dtRela        = 7
-	dtRelasz      = 8
-	dtStrsz       = 10
-	dtSyment      = 11
-	dtInit        = 12
-	dtFini        = 13
-	dtJmprel      = 23
-	dtInitArray   = 25
-	dtFiniArray   = 26
-	dtInitArraySz = 27
-	dtFiniArraySz = 28
-	dtRelr        = 36
-	dtRelrsz      = 35
-	dtGnuHash     = 0x6ffffef5
-	dtVersym      = 0x6ffffff0
-	dtVerdef      = 0x6ffffffc
-	dtVerdefnum   = 0x6ffffffd
-	dtVerneed     = 0x6ffffffe
-	dtVerneednum  = 0x6fffffff
+	dtNull          = 0
+	dtPltrelsz      = 2
+	dtPltgot        = 3
+	dtHash          = 4
+	dtStrtab        = 5
+	dtSymtab        = 6
+	dtRela          = 7
+	dtRelasz        = 8
+	dtStrsz         = 10
+	dtSyment        = 11
+	dtInit          = 12
+	dtFini          = 13
+	dtRel           = 17
+	dtRelsz         = 18
+	dtPltrel        = 20
+	dtJmprel        = 23
+	dtInitArray     = 25
+	dtFiniArray     = 26
+	dtInitArraySz   = 27
+	dtFiniArraySz   = 28
+	dtRelr          = 36
+	dtRelrsz        = 35
+	dtAndroidRel    = 0x6000000f
+	dtAndroidRelsz  = 0x60000010
+	dtAndroidRela   = 0x60000011
+	dtAndroidRelasz = 0x60000012
+	dtAndroidRelr   = 0x6fffe000
+	dtAndroidRelrsz = 0x6fffe001
+	dtGnuHash       = 0x6ffffef5
+	dtVersym        = 0x6ffffff0
+	dtVerdef        = 0x6ffffffc
+	dtVerdefnum     = 0x6ffffffd
+	dtVerneed       = 0x6ffffffe
+	dtVerneednum    = 0x6fffffff
 )
 
 var le = binary.LittleEndian
+
+// elfLayout abstracts the byte-level differences between ELF32 and ELF64 so the
+// rebuild logic can be written once. All accessors take a slice positioned at
+// the start of the relevant structure (or the whole file, for the header) and
+// return class-normalized uint64s.
+type elfLayout struct{ is64 bool }
+
+func (l elfLayout) ehdrSize() int { return pick(l.is64, 64, 52) }
+func (l elfLayout) phdrSize() int { return pick(l.is64, 56, 32) }
+func (l elfLayout) shdrSize() int { return pick(l.is64, 64, 40) }
+func (l elfLayout) dynSize() int  { return pick(l.is64, 16, 8) }
+func (l elfLayout) symSize() int  { return pick(l.is64, 24, 16) }
+func (l elfLayout) word() uint64  { return uint64(pick(l.is64, 8, 4)) }
+
+func pick(is64 bool, a, b int) int {
+	if is64 {
+		return a
+	}
+	return b
+}
+
+// readAddr reads a class-sized (8- or 4-byte) field at the given per-class offset.
+func (l elfLayout) readAddr(b []byte, off64, off32 int) uint64 {
+	if l.is64 {
+		return le.Uint64(b[off64 : off64+8])
+	}
+	return uint64(le.Uint32(b[off32 : off32+4]))
+}
+
+func (l elfLayout) putAddr(b []byte, off64, off32 int, v uint64) {
+	if l.is64 {
+		le.PutUint64(b[off64:off64+8], v)
+	} else {
+		le.PutUint32(b[off32:off32+4], uint32(v))
+	}
+}
+
+// ELF header accessors
+func (l elfLayout) phoff(d []byte) uint64 { return l.readAddr(d, 32, 28) }
+func (l elfLayout) phentsize(d []byte) int {
+	return int(le.Uint16(d[pick(l.is64, 54, 42):]))
+}
+func (l elfLayout) phnum(d []byte) int          { return int(le.Uint16(d[pick(l.is64, 56, 44):])) }
+func (l elfLayout) setShoff(d []byte, v uint64) { l.putAddr(d, 40, 32, v) }
+func (l elfLayout) setShentsize(d []byte, v uint16) {
+	le.PutUint16(d[pick(l.is64, 58, 46):], v)
+}
+func (l elfLayout) setShnum(d []byte, v uint16)    { le.PutUint16(d[pick(l.is64, 60, 48):], v) }
+func (l elfLayout) setShstrndx(d []byte, v uint16) { le.PutUint16(d[pick(l.is64, 62, 50):], v) }
+
+// Program header accessors (b positioned at a phdr entry)
+func (l elfLayout) pType(b []byte) uint32 { return le.Uint32(b[0:4]) }
+func (l elfLayout) pFlags(b []byte) uint32 {
+	if l.is64 {
+		return le.Uint32(b[4:8])
+	}
+	return le.Uint32(b[24:28])
+}
+func (l elfLayout) pVaddr(b []byte) uint64        { return l.readAddr(b, 16, 8) }
+func (l elfLayout) pFilesz(b []byte) uint64       { return l.readAddr(b, 32, 16) }
+func (l elfLayout) pMemsz(b []byte) uint64        { return l.readAddr(b, 40, 20) }
+func (l elfLayout) setPOffset(b []byte, v uint64) { l.putAddr(b, 8, 4, v) }
+func (l elfLayout) setPFilesz(b []byte, v uint64) { l.putAddr(b, 32, 16, v) }
+
+// Dynamic entry accessors (b positioned at a dyn entry)
+func (l elfLayout) dTag(b []byte) int64 {
+	if l.is64 {
+		return int64(le.Uint64(b[0:8]))
+	}
+	return int64(int32(le.Uint32(b[0:4])))
+}
+func (l elfLayout) dVal(b []byte) uint64 { return l.readAddr(b, 8, 4) }
+
+// Symbol accessors (b positioned at a sym entry). NB: ELF32 and ELF64 order
+// their fields differently, so these are not simple width swaps.
+func (l elfLayout) symValue(b []byte) uint64 {
+	if l.is64 {
+		return le.Uint64(b[8:16])
+	}
+	return uint64(le.Uint32(b[4:8]))
+}
+func (l elfLayout) symInfo(b []byte) byte {
+	if l.is64 {
+		return b[4]
+	}
+	return b[12]
+}
+func (l elfLayout) symShndxOff() int { return pick(l.is64, 6, 14) }
+func (l elfLayout) symShndx(b []byte) uint16 {
+	return le.Uint16(b[l.symShndxOff():])
+}
+func (l elfLayout) setSymShndx(b []byte, v uint16) { le.PutUint16(b[l.symShndxOff():], v) }
+
+// putShdr writes one section header entry in the right class layout.
+func (l elfLayout) putShdr(b []byte, name, typ uint32, flags, addr, off, size uint64, link, info uint32, align, entsize uint64) {
+	le.PutUint32(b[0:4], name)
+	le.PutUint32(b[4:8], typ)
+	if l.is64 {
+		le.PutUint64(b[8:16], flags)
+		le.PutUint64(b[16:24], addr)
+		le.PutUint64(b[24:32], off)
+		le.PutUint64(b[32:40], size)
+		le.PutUint32(b[40:44], link)
+		le.PutUint32(b[44:48], info)
+		le.PutUint64(b[48:56], align)
+		le.PutUint64(b[56:64], entsize)
+	} else {
+		le.PutUint32(b[8:12], uint32(flags))
+		le.PutUint32(b[12:16], uint32(addr))
+		le.PutUint32(b[16:20], uint32(off))
+		le.PutUint32(b[20:24], uint32(size))
+		le.PutUint32(b[24:28], link)
+		le.PutUint32(b[28:32], info)
+		le.PutUint32(b[32:36], uint32(align))
+		le.PutUint32(b[36:40], uint32(entsize))
+	}
+}
 
 // secDesc is a work-in-progress section header, with link/info kept as names
 // until the final index assignment.
@@ -97,13 +222,14 @@ type loadSeg struct {
 	flags                uint32
 }
 
-// RebuildSoSections takes a memory image of an ELF64 shared object (as produced
-// by dumping [base,end) from process memory, i.e. bytes live at file offset ==
-// virtual address) and returns a copy with p_offset normalized and a freshly
-// reconstructed section header table appended, so tools like IDA recognize it.
+// RebuildSoSections takes a memory image of an ELF shared object (ELF32 or
+// ELF64, little-endian) as produced by dumping [base,end) from process memory
+// (bytes live at file offset == virtual address) and returns a copy with
+// p_offset normalized and a freshly reconstructed section header table
+// appended, so tools like IDA recognize it.
 //
 // The whole reconstruction is driven by the PT_DYNAMIC segment, which survives
-// in a memory dump: DT_SYMTAB/STRTAB/HASH/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/
+// in a memory dump: DT_SYMTAB/STRTAB/HASH/GNU_HASH/REL/RELA/RELR/JMPREL/PLTGOT/
 // VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY give the addresses (and often the
 // sizes) of the corresponding sections. Sections whose size isn't directly
 // known are sized from the next section's start after sorting by address.
@@ -111,21 +237,28 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 	data := make([]byte, len(image))
 	copy(data, image)
 
-	if len(data) < elf64HeaderSize {
+	if len(data) < 16 {
 		return nil, fmt.Errorf("image too small")
 	}
 	if data[0] != 0x7f || data[1] != 'E' || data[2] != 'L' || data[3] != 'F' {
 		return nil, fmt.Errorf("not an ELF image")
 	}
-	if data[4] != 2 {
-		return nil, fmt.Errorf("only ELF64 supported")
+	if data[4] != 1 && data[4] != 2 {
+		return nil, fmt.Errorf("unsupported EI_CLASS=%d", data[4])
+	}
+	if data[5] != 1 {
+		return nil, fmt.Errorf("only little-endian images supported (EI_DATA=%d)", data[5])
+	}
+	l := elfLayout{is64: data[4] == 2}
+	if len(data) < l.ehdrSize() {
+		return nil, fmt.Errorf("image smaller than ELF header")
 	}
 
-	phoff := le.Uint64(data[32:40])
-	phentsize := int(le.Uint16(data[54:56]))
-	phnum := int(le.Uint16(data[56:58]))
+	phoff := l.phoff(data)
+	phentsize := l.phentsize(data)
+	phnum := l.phnum(data)
 	if phentsize == 0 {
-		phentsize = elf64PhdrSize
+		phentsize = l.phdrSize()
 	}
 	if phoff == 0 || phnum == 0 {
 		return nil, fmt.Errorf("no program headers")
@@ -136,24 +269,25 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 	var dynAddr, dynSize uint64
 	for i := 0; i < phnum; i++ {
 		off := int(phoff) + i*phentsize
-		if off+elf64PhdrSize > len(data) {
+		if off+l.phdrSize() > len(data) {
 			break
 		}
-		pType := le.Uint32(data[off : off+4])
-		pFlags := le.Uint32(data[off+4 : off+8])
-		pVaddr := le.Uint64(data[off+16 : off+24])
-		pFilesz := le.Uint64(data[off+32 : off+40])
-		pMemsz := le.Uint64(data[off+40 : off+48])
+		ph := data[off:]
+		pType := l.pType(ph)
+		pFlags := l.pFlags(ph)
+		pVaddr := l.pVaddr(ph)
+		pFilesz := l.pFilesz(ph)
+		pMemsz := l.pMemsz(ph)
 
 		// memory image: file offset equals virtual address
-		le.PutUint64(data[off+8:off+16], pVaddr)
+		l.setPOffset(ph, pVaddr)
 
 		switch pType {
 		case ptLoad:
 			loads = append(loads, loadSeg{vaddr: pVaddr, filesz: pFilesz, memsz: pMemsz, flags: pFlags})
 			if pMemsz > pFilesz {
 				// in a memory image the whole segment is present
-				le.PutUint64(data[off+32:off+40], pMemsz)
+				l.setPFilesz(ph, pMemsz)
 			}
 		case ptDynamic:
 			dynAddr = pVaddr
@@ -169,23 +303,24 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 
 	var minVaddr, maxVaddr uint64 = ^uint64(0), 0
 	var loadFileEnd uint64 // highest vaddr backed by file bytes (end of .data, before .bss)
-	for _, l := range loads {
-		if l.vaddr < minVaddr {
-			minVaddr = l.vaddr
+	for _, seg := range loads {
+		if seg.vaddr < minVaddr {
+			minVaddr = seg.vaddr
 		}
-		if l.vaddr+l.memsz > maxVaddr {
-			maxVaddr = l.vaddr + l.memsz
+		if seg.vaddr+seg.memsz > maxVaddr {
+			maxVaddr = seg.vaddr + seg.memsz
 		}
-		if end := l.vaddr + l.filesz; end > loadFileEnd {
+		if end := seg.vaddr + seg.filesz; end > loadFileEnd {
 			loadFileEnd = end
 		}
 	}
 
 	// Parse the dynamic segment (singleton tags only; NEEDED etc. are irrelevant).
 	dyn := map[int64]uint64{}
-	for off := int(dynAddr); off+elf64DynSize <= len(data) && off+elf64DynSize <= int(dynAddr+dynSize); off += elf64DynSize {
-		tag := int64(le.Uint64(data[off : off+8]))
-		val := le.Uint64(data[off+8 : off+16])
+	dynEnt := l.dynSize()
+	for off := int(dynAddr); off+dynEnt <= len(data) && off+dynEnt <= int(dynAddr)+int(dynSize); off += dynEnt {
+		tag := l.dTag(data[off:])
+		val := l.dVal(data[off:])
 		if tag == dtNull {
 			break
 		}
@@ -201,8 +336,12 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 		nchain := le.Uint32(data[int(h)+4 : int(h)+8])
 		symcount = int(nchain)
 	} else if gh, ok := get(dtGnuHash); ok {
-		symcount = gnuHashSymCount(data, int(gh))
+		symcount = gnuHashSymCount(l, data, int(gh))
 	}
+
+	symEnt := uint64(l.symSize())
+	relaEnt := uint64(pick(l.is64, 24, 12))
+	relEnt := uint64(pick(l.is64, 16, 8))
 
 	var secs []secDesc
 	secs = append(secs, secDesc{name: ""}) // index 0 is always the NULL section
@@ -211,22 +350,22 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 	strsz, _ := get(dtStrsz)
 
 	if gh, ok := get(dtGnuHash); ok {
-		secs = append(secs, secDesc{name: ".gnu.hash", typ: shtGnuHash, flags: shfAlloc, addr: gh, linkName: ".dynsym", align: 8})
+		secs = append(secs, secDesc{name: ".gnu.hash", typ: shtGnuHash, flags: shfAlloc, addr: gh, linkName: ".dynsym", align: l.word()})
 	}
 	if h, ok := get(dtHash); ok {
-		secs = append(secs, secDesc{name: ".hash", typ: shtHash, flags: shfAlloc, addr: h, linkName: ".dynsym", entsize: 4, align: 8})
+		secs = append(secs, secDesc{name: ".hash", typ: shtHash, flags: shfAlloc, addr: h, linkName: ".dynsym", entsize: 4, align: l.word()})
 	}
 	if sym, ok := get(dtSymtab); ok {
 		syment, ok2 := get(dtSyment)
 		if !ok2 || syment == 0 {
-			syment = elf64SymSize
+			syment = symEnt
 		}
-		d := secDesc{name: ".dynsym", typ: shtDynsym, flags: shfAlloc, addr: sym, linkName: ".dynstr", entsize: syment, align: 8}
+		d := secDesc{name: ".dynsym", typ: shtDynsym, flags: shfAlloc, addr: sym, linkName: ".dynstr", entsize: syment, align: l.word()}
 		if symcount > 0 {
 			d.size = uint64(symcount) * syment
 			d.hasSize = true
 		}
-		d.info = uint32(countLocalSyms(data, int(sym), symcount))
+		d.info = uint32(countLocalSyms(l, data, int(sym), symcount))
 		secs = append(secs, d)
 	}
 	if hasStrtab {
@@ -246,14 +385,14 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 		secs = append(secs, d)
 	}
 	if vd, ok := get(dtVerdef); ok {
-		d := secDesc{name: ".gnu.version_d", typ: shtGnuVerdef, flags: shfAlloc, addr: vd, linkName: ".dynstr", align: 8}
+		d := secDesc{name: ".gnu.version_d", typ: shtGnuVerdef, flags: shfAlloc, addr: vd, linkName: ".dynstr", align: l.word()}
 		if cnt, ok2 := get(dtVerdefnum); ok2 {
 			d.info = uint32(cnt)
 		}
 		secs = append(secs, d)
 	}
 	if vn, ok := get(dtVerneed); ok {
-		d := secDesc{name: ".gnu.version_r", typ: shtGnuVerneed, flags: shfAlloc, addr: vn, linkName: ".dynstr", align: 8}
+		d := secDesc{name: ".gnu.version_r", typ: shtGnuVerneed, flags: shfAlloc, addr: vn, linkName: ".dynstr", align: l.word()}
 		if cnt, ok2 := get(dtVerneednum); ok2 {
 			d.info = uint32(cnt)
 		}
@@ -261,25 +400,80 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 	}
 	if rela, ok := get(dtRela); ok {
 		relasz, _ := get(dtRelasz)
-		d := secDesc{name: ".rela.dyn", typ: shtRela, flags: shfAlloc, addr: rela, linkName: ".dynsym", entsize: 0x18, align: 8}
+		d := secDesc{name: ".rela.dyn", typ: shtRela, flags: shfAlloc, addr: rela, linkName: ".dynsym", entsize: relaEnt, align: l.word()}
 		if relasz > 0 {
 			d.size = relasz
 			d.hasSize = true
 		}
 		secs = append(secs, d)
 	}
+	if rel, ok := get(dtRel); ok {
+		relsz, _ := get(dtRelsz)
+		d := secDesc{name: ".rel.dyn", typ: shtRel, flags: shfAlloc, addr: rel, linkName: ".dynsym", entsize: relEnt, align: l.word()}
+		if relsz > 0 {
+			d.size = relsz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
 	if relr, ok := get(dtRelr); ok {
 		relrsz, _ := get(dtRelrsz)
-		d := secDesc{name: ".relr.dyn", typ: shtRelr, flags: shfAlloc, addr: relr, entsize: 8, align: 8}
+		d := secDesc{name: ".relr.dyn", typ: shtRelr, flags: shfAlloc, addr: relr, entsize: l.word(), align: l.word()}
 		if relrsz > 0 {
 			d.size = relrsz
 			d.hasSize = true
 		}
 		secs = append(secs, d)
 	}
+	// Android packed relocations (common in Android hardeners and older NDK
+	// output). The payload stays packed (APS2 stream for REL/RELA, bitmap for
+	// RELR); we only anchor a correctly typed section header at it so IDA and
+	// readelf decode it. These tags are mutually exclusive with the standard
+	// DT_REL/DT_RELA/DT_RELR above, so no section name collides in practice.
+	if ar, ok := get(dtAndroidRela); ok {
+		arsz, _ := get(dtAndroidRelasz)
+		d := secDesc{name: ".rela.dyn", typ: shtAndroidRela, flags: shfAlloc, addr: ar, linkName: ".dynsym", align: l.word()}
+		if arsz > 0 {
+			d.size = arsz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if ar, ok := get(dtAndroidRel); ok {
+		arsz, _ := get(dtAndroidRelsz)
+		d := secDesc{name: ".rel.dyn", typ: shtAndroidRel, flags: shfAlloc, addr: ar, linkName: ".dynsym", align: l.word()}
+		if arsz > 0 {
+			d.size = arsz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if ar, ok := get(dtAndroidRelr); ok {
+		arsz, _ := get(dtAndroidRelrsz)
+		d := secDesc{name: ".relr.dyn", typ: shtAndroidRelr, flags: shfAlloc, addr: ar, entsize: l.word(), align: l.word()}
+		if arsz > 0 {
+			d.size = arsz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	// .rela.plt / .rel.plt — the JMPREL table; its form (REL vs RELA) follows
+	// DT_PLTREL (defaulting to the arch norm: RELA on 64-bit, REL on 32-bit).
+	pltIsRela := l.is64
+	if pr, ok := get(dtPltrel); ok {
+		pltIsRela = pr == uint64(dtRela)
+	}
+	pltRelEnt := relEnt
+	if pltIsRela {
+		pltRelEnt = relaEnt
+	}
 	if jmp, ok := get(dtJmprel); ok {
 		pltrelsz, _ := get(dtPltrelsz)
-		d := secDesc{name: ".rela.plt", typ: shtRela, flags: shfAlloc | shfInfoLink, addr: jmp, linkName: ".dynsym", infoName: ".got.plt", entsize: 0x18, align: 8}
+		name, typ := ".rel.plt", uint32(shtRel)
+		if pltIsRela {
+			name, typ = ".rela.plt", shtRela
+		}
+		d := secDesc{name: name, typ: typ, flags: shfAlloc | shfInfoLink, addr: jmp, linkName: ".dynsym", infoName: ".got.plt", entsize: pltRelEnt, align: l.word()}
 		if pltrelsz > 0 {
 			d.size = pltrelsz
 			d.hasSize = true
@@ -289,8 +483,8 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 	if ini, ok := get(dtInit); ok {
 		secs = append(secs, secDesc{name: ".init", typ: shtProgbits, flags: shfAlloc | shfExec, addr: ini, align: 4})
 	}
-	// .plt starts right after .rela.plt; its exact size is arch-dependent, so
-	// the neighbor-based pass finalizes it from the next section's start.
+	// .plt starts right after the JMPREL table; its exact size is arch-dependent,
+	// so the neighbor-based pass finalizes it from the next section's start.
 	if jmp, ok := get(dtJmprel); ok {
 		pltrelsz, _ := get(dtPltrelsz)
 		pltAddr := (jmp + pltrelsz + 0xf) &^ 0xf
@@ -306,11 +500,11 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 		textStart = (jmp + pltrelsz + 0xf) &^ 0xf
 	}
 	if textStart != 0 {
-		secs = append(secs, secDesc{name: ".text", typ: shtProgbits, flags: shfAlloc | shfExec, addr: textStart + 0x40, align: 8})
+		secs = append(secs, secDesc{name: ".text", typ: shtProgbits, flags: shfAlloc | shfExec, addr: textStart + 0x40, align: l.word()})
 	}
 	if ia, ok := get(dtInitArray); ok {
 		iasz, _ := get(dtInitArraySz)
-		d := secDesc{name: ".init_array", typ: shtInitArray, flags: shfWrite | shfAlloc, addr: ia, entsize: 8, align: 8}
+		d := secDesc{name: ".init_array", typ: shtInitArray, flags: shfWrite | shfAlloc, addr: ia, entsize: l.word(), align: l.word()}
 		if iasz > 0 {
 			d.size = iasz
 			d.hasSize = true
@@ -319,31 +513,33 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 	}
 	if fa, ok := get(dtFiniArray); ok {
 		fasz, _ := get(dtFiniArraySz)
-		d := secDesc{name: ".fini_array", typ: shtFiniArray, flags: shfWrite | shfAlloc, addr: fa, entsize: 8, align: 8}
+		d := secDesc{name: ".fini_array", typ: shtFiniArray, flags: shfWrite | shfAlloc, addr: fa, entsize: l.word(), align: l.word()}
 		if fasz > 0 {
 			d.size = fasz
 			d.hasSize = true
 		}
 		secs = append(secs, d)
 	}
-	secs = append(secs, secDesc{name: ".dynamic", typ: shtDynamic, flags: shfWrite | shfAlloc, addr: dynAddr, size: dynSize, hasSize: true, linkName: ".dynstr", entsize: 0x10, align: 8})
+	secs = append(secs, secDesc{name: ".dynamic", typ: shtDynamic, flags: shfWrite | shfAlloc, addr: dynAddr, size: dynSize, hasSize: true, linkName: ".dynstr", entsize: uint64(dynEnt), align: l.word()})
 	// .got.plt (DT_PLTGOT): standard layout is 3 reserved GOT slots followed by
-	// one slot per PLT relocation, so its size is (3 + pltRelCount) * 8.
+	// one slot per PLT relocation, so its size is (3 + pltRelCount) * wordsize.
 	var gotPltEnd uint64
 	if got, ok := get(dtPltgot); ok {
-		d := secDesc{name: ".got.plt", typ: shtProgbits, flags: shfWrite | shfAlloc, addr: got, entsize: 8, align: 8}
-		if pltrelsz, ok2 := get(dtPltrelsz); ok2 && pltrelsz > 0 {
-			d.size = (3 + pltrelsz/0x18) * 8
+		d := secDesc{name: ".got.plt", typ: shtProgbits, flags: shfWrite | shfAlloc, addr: got, entsize: l.word(), align: l.word()}
+		if pltrelsz, ok2 := get(dtPltrelsz); ok2 && pltrelsz > 0 && pltRelEnt > 0 {
+			d.size = (3 + pltrelsz/pltRelEnt) * l.word()
 			d.hasSize = true
 			gotPltEnd = got + d.size
 		}
 		secs = append(secs, d)
 	}
+	// .data: from the end of .got.plt up to the file-backed load end.
+	// .bss: the memsz-beyond-filesz tail.
 	if gotPltEnd > 0 && gotPltEnd < loadFileEnd {
-		secs = append(secs, secDesc{name: ".data", typ: shtProgbits, flags: shfWrite | shfAlloc, addr: gotPltEnd, align: 8})
+		secs = append(secs, secDesc{name: ".data", typ: shtProgbits, flags: shfWrite | shfAlloc, addr: gotPltEnd, align: l.word()})
 	}
 	if maxVaddr > loadFileEnd {
-		secs = append(secs, secDesc{name: ".bss", typ: shtNobits, flags: shfWrite | shfAlloc, addr: loadFileEnd, size: maxVaddr - loadFileEnd, hasSize: true, align: 8})
+		secs = append(secs, secDesc{name: ".bss", typ: shtNobits, flags: shfWrite | shfAlloc, addr: loadFileEnd, size: maxVaddr - loadFileEnd, hasSize: true, align: l.word()})
 	}
 
 	// Sort allocatable sections by address (NULL stays at index 0).
@@ -405,20 +601,21 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 	// section layout; remap each defined symbol to the rebuilt section that
 	// contains its address so the indexes are valid again.
 	if symAddr, ok := get(dtSymtab); ok && symcount > 0 {
-		remapSymShndx(data, int(symAddr), symcount, secs)
+		remapSymShndx(l, data, int(symAddr), symcount, secs)
 	}
 
 	// Lay out appended data at end of file: [.shstrtab][shdr table].
 	shstrtabOff := uint64(len(data))
 	data = append(data, shstrtab...)
-	for len(data)%8 != 0 { // align shdr table
+	for len(data)%int(l.word()) != 0 { // align shdr table to class word size
 		data = append(data, 0)
 	}
 	shoff := uint64(len(data))
 
-	shtable := make([]byte, len(secs)*elf64ShdrSize)
+	shdrSize := l.shdrSize()
+	shtable := make([]byte, len(secs)*shdrSize)
 	for i, s := range secs {
-		b := shtable[i*elf64ShdrSize : (i+1)*elf64ShdrSize]
+		b := shtable[i*shdrSize : (i+1)*shdrSize]
 		var shName uint32
 		if s.name != "" {
 			shName = nameOff[s.name]
@@ -442,48 +639,57 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 		if s.infoName != "" {
 			info = idxOf[s.infoName]
 		}
-		le.PutUint32(b[0:4], shName)
-		le.PutUint32(b[4:8], s.typ)
-		le.PutUint64(b[8:16], s.flags)
-		le.PutUint64(b[16:24], shAddr)
-		le.PutUint64(b[24:32], shOffset)
-		le.PutUint64(b[32:40], shSize)
-		le.PutUint32(b[40:44], link)
-		le.PutUint32(b[44:48], info)
-		le.PutUint64(b[48:56], s.align)
-		le.PutUint64(b[56:64], s.entsize)
+		l.putShdr(b, shName, s.typ, s.flags, shAddr, shOffset, shSize, link, info, s.align, s.entsize)
 	}
 	data = append(data, shtable...)
 
 	// Patch the ELF header to point at the rebuilt table.
-	le.PutUint64(data[40:48], shoff)
-	le.PutUint16(data[58:60], elf64ShdrSize)
-	le.PutUint16(data[60:62], uint16(len(secs)))
-	le.PutUint16(data[62:64], uint16(shstrtabIdx))
+	l.setShoff(data, shoff)
+	l.setShentsize(data, uint16(shdrSize))
+	l.setShnum(data, uint16(len(secs)))
+	l.setShstrndx(data, uint16(shstrtabIdx))
 
 	return data, nil
+}
+
+// SelfCheckSo parses rebuilt ELF bytes the way IDA/BFD would — strictly, via
+// the section header table — and returns how many dynamic symbols are
+// readable, as a confidence signal that the rebuild is loadable and useful.
+func SelfCheckSo(data []byte) (int, error) {
+	f, err := elf.NewFile(bytes.NewReader(data))
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	syms, err := f.DynamicSymbols()
+	if err != nil {
+		return 0, err
+	}
+	return len(syms), nil
 }
 
 // remapSymShndx rewrites each defined .dynsym entry's st_shndx to the rebuilt
 // allocatable section whose address range contains the symbol's value. UND (0)
 // and reserved (>=0xff00, e.g. SHN_ABS) entries are left untouched.
-func remapSymShndx(data []byte, off, count int, secs []secDesc) {
+func remapSymShndx(l elfLayout, data []byte, off, count int, secs []secDesc) {
+	symSize := l.symSize()
 	for i := 0; i < count; i++ {
-		o := off + i*elf64SymSize
-		if o+elf64SymSize > len(data) {
+		o := off + i*symSize
+		if o+symSize > len(data) {
 			break
 		}
-		shndx := le.Uint16(data[o+6 : o+8])
+		b := data[o:]
+		shndx := l.symShndx(b)
 		if shndx == 0 || shndx >= 0xff00 {
 			continue
 		}
-		value := le.Uint64(data[o+8 : o+16])
+		value := l.symValue(b)
 		for si, s := range secs {
 			if s.flags&shfAlloc == 0 || s.size == 0 {
 				continue
 			}
 			if value >= s.addr && value < s.addr+s.size {
-				le.PutUint16(data[o+6:o+8], uint16(si))
+				l.setSymShndx(b, uint16(si))
 				break
 			}
 		}
@@ -492,8 +698,10 @@ func remapSymShndx(data []byte, off, count int, secs []secDesc) {
 
 // gnuHashSymCount derives the dynamic symbol count from a DT_GNU_HASH table,
 // which (unlike DT_HASH) has no explicit symbol count: walk the hash chain of
-// the highest-indexed bucket until its terminator bit is set.
-func gnuHashSymCount(data []byte, off int) int {
+// the highest-indexed bucket until its terminator bit is set. The bloom filter
+// is word-sized (4 bytes on ELF32, 8 on ELF64); buckets and the chain array are
+// always 32-bit.
+func gnuHashSymCount(l elfLayout, data []byte, off int) int {
 	if off+16 > len(data) {
 		return 0
 	}
@@ -503,7 +711,7 @@ func gnuHashSymCount(data []byte, off int) int {
 	if nbuckets == 0 {
 		return symoffset
 	}
-	bucketsOff := off + 16 + bloomSize*8
+	bucketsOff := off + 16 + bloomSize*int(l.word())
 	chainBase := bucketsOff + nbuckets*4
 	if chainBase > len(data) {
 		return 0
@@ -539,17 +747,18 @@ func gnuHashSymCount(data []byte, off int) int {
 
 // countLocalSyms counts leading STB_LOCAL entries (st_info>>4 == 0) to seed
 // .dynsym sh_info. Best-effort; IDA doesn't depend on it being exact.
-func countLocalSyms(data []byte, off, count int) int {
+func countLocalSyms(l elfLayout, data []byte, off, count int) int {
 	if count <= 0 {
 		return 1
 	}
+	symSize := l.symSize()
 	locals := 0
 	for i := 0; i < count; i++ {
-		o := off + i*elf64SymSize
-		if o+elf64SymSize > len(data) {
+		o := off + i*symSize
+		if o+symSize > len(data) {
 			break
 		}
-		if data[o+4]>>4 == 0 { // STB_LOCAL
+		if l.symInfo(data[o:])>>4 == 0 { // STB_LOCAL
 			locals++
 		} else {
 			break

--- a/so_rebuild.go
+++ b/so_rebuild.go
@@ -1,0 +1,562 @@
+//go:build arm64
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+)
+
+// ELF64 structure sizes (elf64HeaderSize/elf64PhdrSize live in fix_so.go).
+const (
+	elf64ShdrSize = 64
+	elf64DynSize  = 16
+	elf64SymSize  = 24
+)
+
+// program header type (ptLoad lives in fix_so.go)
+const ptDynamic = 2
+
+// section header types
+const (
+	shtNull       = 0
+	shtProgbits   = 1
+	shtStrtab     = 3
+	shtRela       = 4
+	shtHash       = 5
+	shtDynamic    = 6
+	shtNobits     = 8
+	shtDynsym     = 11
+	shtInitArray  = 14
+	shtFiniArray  = 15
+	shtRelr       = 19
+	shtGnuHash    = 0x6ffffff6
+	shtGnuVerdef  = 0x6ffffffd
+	shtGnuVerneed = 0x6ffffffe
+	shtGnuVersym  = 0x6fffffff
+)
+
+// section header flags
+const (
+	shfWrite    = 0x1
+	shfAlloc    = 0x2
+	shfExec     = 0x4
+	shfInfoLink = 0x40
+)
+
+// dynamic tags
+const (
+	dtNull        = 0
+	dtPltrelsz    = 2
+	dtPltgot      = 3
+	dtHash        = 4
+	dtStrtab      = 5
+	dtSymtab      = 6
+	dtRela        = 7
+	dtRelasz      = 8
+	dtStrsz       = 10
+	dtSyment      = 11
+	dtInit        = 12
+	dtFini        = 13
+	dtJmprel      = 23
+	dtInitArray   = 25
+	dtFiniArray   = 26
+	dtInitArraySz = 27
+	dtFiniArraySz = 28
+	dtRelr        = 36
+	dtRelrsz      = 35
+	dtGnuHash     = 0x6ffffef5
+	dtVersym      = 0x6ffffff0
+	dtVerdef      = 0x6ffffffc
+	dtVerdefnum   = 0x6ffffffd
+	dtVerneed     = 0x6ffffffe
+	dtVerneednum  = 0x6fffffff
+)
+
+var le = binary.LittleEndian
+
+// secDesc is a work-in-progress section header, with link/info kept as names
+// until the final index assignment.
+type secDesc struct {
+	name     string
+	typ      uint32
+	flags    uint64
+	addr     uint64
+	size     uint64
+	hasSize  bool // true if size is known precisely (don't overwrite via neighbor calc)
+	linkName string
+	infoName string
+	info     uint32
+	entsize  uint64
+	align    uint64
+}
+
+type loadSeg struct {
+	vaddr, filesz, memsz uint64
+	flags                uint32
+}
+
+// RebuildSoSections takes a memory image of an ELF64 shared object (as produced
+// by dumping [base,end) from process memory, i.e. bytes live at file offset ==
+// virtual address) and returns a copy with p_offset normalized and a freshly
+// reconstructed section header table appended, so tools like IDA recognize it.
+//
+// The whole reconstruction is driven by the PT_DYNAMIC segment, which survives
+// in a memory dump: DT_SYMTAB/STRTAB/HASH/GNU_HASH/RELA/RELR/JMPREL/PLTGOT/
+// VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY give the addresses (and often the
+// sizes) of the corresponding sections. Sections whose size isn't directly
+// known are sized from the next section's start after sorting by address.
+func RebuildSoSections(image []byte) ([]byte, error) {
+	data := make([]byte, len(image))
+	copy(data, image)
+
+	if len(data) < elf64HeaderSize {
+		return nil, fmt.Errorf("image too small")
+	}
+	if data[0] != 0x7f || data[1] != 'E' || data[2] != 'L' || data[3] != 'F' {
+		return nil, fmt.Errorf("not an ELF image")
+	}
+	if data[4] != 2 {
+		return nil, fmt.Errorf("only ELF64 supported")
+	}
+
+	phoff := le.Uint64(data[32:40])
+	phentsize := int(le.Uint16(data[54:56]))
+	phnum := int(le.Uint16(data[56:58]))
+	if phentsize == 0 {
+		phentsize = elf64PhdrSize
+	}
+	if phoff == 0 || phnum == 0 {
+		return nil, fmt.Errorf("no program headers")
+	}
+
+	// Parse program headers: normalize p_offset=p_vaddr, collect LOADs + DYNAMIC.
+	var loads []loadSeg
+	var dynAddr, dynSize uint64
+	for i := 0; i < phnum; i++ {
+		off := int(phoff) + i*phentsize
+		if off+elf64PhdrSize > len(data) {
+			break
+		}
+		pType := le.Uint32(data[off : off+4])
+		pFlags := le.Uint32(data[off+4 : off+8])
+		pVaddr := le.Uint64(data[off+16 : off+24])
+		pFilesz := le.Uint64(data[off+32 : off+40])
+		pMemsz := le.Uint64(data[off+40 : off+48])
+
+		// memory image: file offset equals virtual address
+		le.PutUint64(data[off+8:off+16], pVaddr)
+
+		switch pType {
+		case ptLoad:
+			loads = append(loads, loadSeg{vaddr: pVaddr, filesz: pFilesz, memsz: pMemsz, flags: pFlags})
+			if pMemsz > pFilesz {
+				// in a memory image the whole segment is present
+				le.PutUint64(data[off+32:off+40], pMemsz)
+			}
+		case ptDynamic:
+			dynAddr = pVaddr
+			dynSize = pMemsz
+		}
+	}
+	if dynAddr == 0 {
+		return nil, fmt.Errorf("no PT_DYNAMIC segment; cannot rebuild sections")
+	}
+	if len(loads) == 0 {
+		return nil, fmt.Errorf("no PT_LOAD segments")
+	}
+
+	var minVaddr, maxVaddr uint64 = ^uint64(0), 0
+	var loadFileEnd uint64 // highest vaddr backed by file bytes (end of .data, before .bss)
+	for _, l := range loads {
+		if l.vaddr < minVaddr {
+			minVaddr = l.vaddr
+		}
+		if l.vaddr+l.memsz > maxVaddr {
+			maxVaddr = l.vaddr + l.memsz
+		}
+		if end := l.vaddr + l.filesz; end > loadFileEnd {
+			loadFileEnd = end
+		}
+	}
+
+	// Parse the dynamic segment (singleton tags only; NEEDED etc. are irrelevant).
+	dyn := map[int64]uint64{}
+	for off := int(dynAddr); off+elf64DynSize <= len(data) && off+elf64DynSize <= int(dynAddr+dynSize); off += elf64DynSize {
+		tag := int64(le.Uint64(data[off : off+8]))
+		val := le.Uint64(data[off+8 : off+16])
+		if tag == dtNull {
+			break
+		}
+		dyn[tag] = val
+	}
+
+	get := func(tag int64) (uint64, bool) { v, ok := dyn[tag]; return v, ok }
+
+	// Determine dynamic symbol count (needed for .dynsym / .gnu.version sizes).
+	symcount := 0
+	if h, ok := get(dtHash); ok && int(h)+8 <= len(data) {
+		// SysV hash: nchain (at +4) == number of symbol table entries
+		nchain := le.Uint32(data[int(h)+4 : int(h)+8])
+		symcount = int(nchain)
+	} else if gh, ok := get(dtGnuHash); ok {
+		symcount = gnuHashSymCount(data, int(gh))
+	}
+
+	var secs []secDesc
+	secs = append(secs, secDesc{name: ""}) // index 0 is always the NULL section
+
+	strtabAddr, hasStrtab := get(dtStrtab)
+	strsz, _ := get(dtStrsz)
+
+	if gh, ok := get(dtGnuHash); ok {
+		secs = append(secs, secDesc{name: ".gnu.hash", typ: shtGnuHash, flags: shfAlloc, addr: gh, linkName: ".dynsym", align: 8})
+	}
+	if h, ok := get(dtHash); ok {
+		secs = append(secs, secDesc{name: ".hash", typ: shtHash, flags: shfAlloc, addr: h, linkName: ".dynsym", entsize: 4, align: 8})
+	}
+	if sym, ok := get(dtSymtab); ok {
+		syment, ok2 := get(dtSyment)
+		if !ok2 || syment == 0 {
+			syment = elf64SymSize
+		}
+		d := secDesc{name: ".dynsym", typ: shtDynsym, flags: shfAlloc, addr: sym, linkName: ".dynstr", entsize: syment, align: 8}
+		if symcount > 0 {
+			d.size = uint64(symcount) * syment
+			d.hasSize = true
+		}
+		d.info = uint32(countLocalSyms(data, int(sym), symcount))
+		secs = append(secs, d)
+	}
+	if hasStrtab {
+		d := secDesc{name: ".dynstr", typ: shtStrtab, flags: shfAlloc, addr: strtabAddr, align: 1}
+		if strsz > 0 {
+			d.size = strsz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if vs, ok := get(dtVersym); ok {
+		d := secDesc{name: ".gnu.version", typ: shtGnuVersym, flags: shfAlloc, addr: vs, linkName: ".dynsym", entsize: 2, align: 2}
+		if symcount > 0 {
+			d.size = uint64(symcount) * 2
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if vd, ok := get(dtVerdef); ok {
+		d := secDesc{name: ".gnu.version_d", typ: shtGnuVerdef, flags: shfAlloc, addr: vd, linkName: ".dynstr", align: 8}
+		if cnt, ok2 := get(dtVerdefnum); ok2 {
+			d.info = uint32(cnt)
+		}
+		secs = append(secs, d)
+	}
+	if vn, ok := get(dtVerneed); ok {
+		d := secDesc{name: ".gnu.version_r", typ: shtGnuVerneed, flags: shfAlloc, addr: vn, linkName: ".dynstr", align: 8}
+		if cnt, ok2 := get(dtVerneednum); ok2 {
+			d.info = uint32(cnt)
+		}
+		secs = append(secs, d)
+	}
+	if rela, ok := get(dtRela); ok {
+		relasz, _ := get(dtRelasz)
+		d := secDesc{name: ".rela.dyn", typ: shtRela, flags: shfAlloc, addr: rela, linkName: ".dynsym", entsize: 0x18, align: 8}
+		if relasz > 0 {
+			d.size = relasz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if relr, ok := get(dtRelr); ok {
+		relrsz, _ := get(dtRelrsz)
+		d := secDesc{name: ".relr.dyn", typ: shtRelr, flags: shfAlloc, addr: relr, entsize: 8, align: 8}
+		if relrsz > 0 {
+			d.size = relrsz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if jmp, ok := get(dtJmprel); ok {
+		pltrelsz, _ := get(dtPltrelsz)
+		d := secDesc{name: ".rela.plt", typ: shtRela, flags: shfAlloc | shfInfoLink, addr: jmp, linkName: ".dynsym", infoName: ".got.plt", entsize: 0x18, align: 8}
+		if pltrelsz > 0 {
+			d.size = pltrelsz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if ini, ok := get(dtInit); ok {
+		secs = append(secs, secDesc{name: ".init", typ: shtProgbits, flags: shfAlloc | shfExec, addr: ini, align: 4})
+	}
+	// .plt starts right after .rela.plt; its exact size is arch-dependent, so
+	// the neighbor-based pass finalizes it from the next section's start.
+	if jmp, ok := get(dtJmprel); ok {
+		pltrelsz, _ := get(dtPltrelsz)
+		pltAddr := (jmp + pltrelsz + 0xf) &^ 0xf
+		secs = append(secs, secDesc{name: ".plt", typ: shtProgbits, flags: shfAlloc | shfExec, addr: pltAddr, entsize: 16, align: 16})
+	}
+	// .text: seeded just past .plt (or .init); size computed from neighbors.
+	textStart := uint64(0)
+	if v, ok := get(dtInit); ok {
+		textStart = v
+	}
+	if jmp, ok := get(dtJmprel); ok {
+		pltrelsz, _ := get(dtPltrelsz)
+		textStart = (jmp + pltrelsz + 0xf) &^ 0xf
+	}
+	if textStart != 0 {
+		secs = append(secs, secDesc{name: ".text", typ: shtProgbits, flags: shfAlloc | shfExec, addr: textStart + 0x40, align: 8})
+	}
+	if ia, ok := get(dtInitArray); ok {
+		iasz, _ := get(dtInitArraySz)
+		d := secDesc{name: ".init_array", typ: shtInitArray, flags: shfWrite | shfAlloc, addr: ia, entsize: 8, align: 8}
+		if iasz > 0 {
+			d.size = iasz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	if fa, ok := get(dtFiniArray); ok {
+		fasz, _ := get(dtFiniArraySz)
+		d := secDesc{name: ".fini_array", typ: shtFiniArray, flags: shfWrite | shfAlloc, addr: fa, entsize: 8, align: 8}
+		if fasz > 0 {
+			d.size = fasz
+			d.hasSize = true
+		}
+		secs = append(secs, d)
+	}
+	secs = append(secs, secDesc{name: ".dynamic", typ: shtDynamic, flags: shfWrite | shfAlloc, addr: dynAddr, size: dynSize, hasSize: true, linkName: ".dynstr", entsize: 0x10, align: 8})
+	// .got.plt (DT_PLTGOT): standard layout is 3 reserved GOT slots followed by
+	// one slot per PLT relocation, so its size is (3 + pltRelCount) * 8.
+	var gotPltEnd uint64
+	if got, ok := get(dtPltgot); ok {
+		d := secDesc{name: ".got.plt", typ: shtProgbits, flags: shfWrite | shfAlloc, addr: got, entsize: 8, align: 8}
+		if pltrelsz, ok2 := get(dtPltrelsz); ok2 && pltrelsz > 0 {
+			d.size = (3 + pltrelsz/0x18) * 8
+			d.hasSize = true
+			gotPltEnd = got + d.size
+		}
+		secs = append(secs, d)
+	}
+	if gotPltEnd > 0 && gotPltEnd < loadFileEnd {
+		secs = append(secs, secDesc{name: ".data", typ: shtProgbits, flags: shfWrite | shfAlloc, addr: gotPltEnd, align: 8})
+	}
+	if maxVaddr > loadFileEnd {
+		secs = append(secs, secDesc{name: ".bss", typ: shtNobits, flags: shfWrite | shfAlloc, addr: loadFileEnd, size: maxVaddr - loadFileEnd, hasSize: true, align: 8})
+	}
+
+	// Sort allocatable sections by address (NULL stays at index 0).
+	body := secs[1:]
+	sort.SliceStable(body, func(i, j int) bool { return body[i].addr < body[j].addr })
+
+	// Neighbor-based size pass: any section without a precise size grows to the
+	// next section's start; precise sizes are clamped only if they'd overlap.
+	for i := 0; i < len(body); i++ {
+		var next uint64
+		if i+1 < len(body) {
+			next = body[i+1].addr
+		} else {
+			next = loadFileEnd
+			if body[i].typ == shtNobits {
+				next = maxVaddr
+			}
+		}
+		if next <= body[i].addr {
+			continue
+		}
+		gap := next - body[i].addr
+		if !body[i].hasSize {
+			body[i].size = gap
+		} else if body[i].size > gap {
+			body[i].size = gap
+		}
+	}
+
+	// Reassemble: NULL + sorted allocatable sections + .shstrtab.
+	secs = append([]secDesc{secs[0]}, body...)
+	shstrtabIdx := len(secs)
+	secs = append(secs, secDesc{name: ".shstrtab", typ: shtStrtab, align: 1})
+
+	// Build the section header string table.
+	shstrtab := []byte{0}
+	nameOff := map[string]uint32{"": 0}
+	for _, s := range secs {
+		if s.name == "" {
+			continue
+		}
+		if _, ok := nameOff[s.name]; ok {
+			continue
+		}
+		nameOff[s.name] = uint32(len(shstrtab))
+		shstrtab = append(shstrtab, []byte(s.name)...)
+		shstrtab = append(shstrtab, 0)
+	}
+
+	// name -> index for link/info resolution
+	idxOf := map[string]uint32{}
+	for i, s := range secs {
+		if s.name != "" {
+			idxOf[s.name] = uint32(i)
+		}
+	}
+
+	// The original st_shndx values in .dynsym point at the (now-gone) original
+	// section layout; remap each defined symbol to the rebuilt section that
+	// contains its address so the indexes are valid again.
+	if symAddr, ok := get(dtSymtab); ok && symcount > 0 {
+		remapSymShndx(data, int(symAddr), symcount, secs)
+	}
+
+	// Lay out appended data at end of file: [.shstrtab][shdr table].
+	shstrtabOff := uint64(len(data))
+	data = append(data, shstrtab...)
+	for len(data)%8 != 0 { // align shdr table
+		data = append(data, 0)
+	}
+	shoff := uint64(len(data))
+
+	shtable := make([]byte, len(secs)*elf64ShdrSize)
+	for i, s := range secs {
+		b := shtable[i*elf64ShdrSize : (i+1)*elf64ShdrSize]
+		var shName uint32
+		if s.name != "" {
+			shName = nameOff[s.name]
+		}
+		var shOffset, shAddr, shSize uint64 = 0, 0, s.size
+		switch s.name {
+		case "":
+			// NULL section: all zero
+		case ".shstrtab":
+			shOffset = shstrtabOff
+			shSize = uint64(len(shstrtab))
+		default:
+			shAddr = s.addr
+			shOffset = s.addr // memory image: offset == addr
+		}
+		var link uint32
+		if s.linkName != "" {
+			link = idxOf[s.linkName]
+		}
+		info := s.info
+		if s.infoName != "" {
+			info = idxOf[s.infoName]
+		}
+		le.PutUint32(b[0:4], shName)
+		le.PutUint32(b[4:8], s.typ)
+		le.PutUint64(b[8:16], s.flags)
+		le.PutUint64(b[16:24], shAddr)
+		le.PutUint64(b[24:32], shOffset)
+		le.PutUint64(b[32:40], shSize)
+		le.PutUint32(b[40:44], link)
+		le.PutUint32(b[44:48], info)
+		le.PutUint64(b[48:56], s.align)
+		le.PutUint64(b[56:64], s.entsize)
+	}
+	data = append(data, shtable...)
+
+	// Patch the ELF header to point at the rebuilt table.
+	le.PutUint64(data[40:48], shoff)
+	le.PutUint16(data[58:60], elf64ShdrSize)
+	le.PutUint16(data[60:62], uint16(len(secs)))
+	le.PutUint16(data[62:64], uint16(shstrtabIdx))
+
+	return data, nil
+}
+
+// remapSymShndx rewrites each defined .dynsym entry's st_shndx to the rebuilt
+// allocatable section whose address range contains the symbol's value. UND (0)
+// and reserved (>=0xff00, e.g. SHN_ABS) entries are left untouched.
+func remapSymShndx(data []byte, off, count int, secs []secDesc) {
+	for i := 0; i < count; i++ {
+		o := off + i*elf64SymSize
+		if o+elf64SymSize > len(data) {
+			break
+		}
+		shndx := le.Uint16(data[o+6 : o+8])
+		if shndx == 0 || shndx >= 0xff00 {
+			continue
+		}
+		value := le.Uint64(data[o+8 : o+16])
+		for si, s := range secs {
+			if s.flags&shfAlloc == 0 || s.size == 0 {
+				continue
+			}
+			if value >= s.addr && value < s.addr+s.size {
+				le.PutUint16(data[o+6:o+8], uint16(si))
+				break
+			}
+		}
+	}
+}
+
+// gnuHashSymCount derives the dynamic symbol count from a DT_GNU_HASH table,
+// which (unlike DT_HASH) has no explicit symbol count: walk the hash chain of
+// the highest-indexed bucket until its terminator bit is set.
+func gnuHashSymCount(data []byte, off int) int {
+	if off+16 > len(data) {
+		return 0
+	}
+	nbuckets := int(le.Uint32(data[off : off+4]))
+	symoffset := int(le.Uint32(data[off+4 : off+8]))
+	bloomSize := int(le.Uint32(data[off+8 : off+12]))
+	if nbuckets == 0 {
+		return symoffset
+	}
+	bucketsOff := off + 16 + bloomSize*8
+	chainBase := bucketsOff + nbuckets*4
+	if chainBase > len(data) {
+		return 0
+	}
+	maxSym := 0
+	for i := 0; i < nbuckets; i++ {
+		o := bucketsOff + i*4
+		if o+4 > len(data) {
+			break
+		}
+		b := int(le.Uint32(data[o : o+4]))
+		if b > maxSym {
+			maxSym = b
+		}
+	}
+	if maxSym < symoffset {
+		return symoffset
+	}
+	sym := maxSym
+	for {
+		o := chainBase + (sym-symoffset)*4
+		if o+4 > len(data) || o < chainBase {
+			break
+		}
+		h := le.Uint32(data[o : o+4])
+		if h&1 != 0 {
+			break
+		}
+		sym++
+	}
+	return sym + 1
+}
+
+// countLocalSyms counts leading STB_LOCAL entries (st_info>>4 == 0) to seed
+// .dynsym sh_info. Best-effort; IDA doesn't depend on it being exact.
+func countLocalSyms(data []byte, off, count int) int {
+	if count <= 0 {
+		return 1
+	}
+	locals := 0
+	for i := 0; i < count; i++ {
+		o := off + i*elf64SymSize
+		if o+elf64SymSize > len(data) {
+			break
+		}
+		if data[o+4]>>4 == 0 { // STB_LOCAL
+			locals++
+		} else {
+			break
+		}
+	}
+	if locals == 0 {
+		return 1
+	}
+	return locals
+}

--- a/so_rebuild.go
+++ b/so_rebuild.go
@@ -17,6 +17,7 @@ const ptDynamic = 2
 const (
 	shtNull        = 0
 	shtProgbits    = 1
+	shtSymtab      = 2
 	shtStrtab      = 3
 	shtRela        = 4
 	shtHash        = 5
@@ -201,6 +202,26 @@ func (l elfLayout) putShdr(b []byte, name, typ uint32, flags, addr, off, size ui
 	}
 }
 
+// putSym writes one symbol table entry in the right class layout. NB: ELF32 and
+// ELF64 order the fields differently.
+func (l elfLayout) putSym(b []byte, name uint32, value, size uint64, info, other byte, shndx uint16) {
+	if l.is64 {
+		le.PutUint32(b[0:4], name)
+		b[4] = info
+		b[5] = other
+		le.PutUint16(b[6:8], shndx)
+		le.PutUint64(b[8:16], value)
+		le.PutUint64(b[16:24], size)
+	} else {
+		le.PutUint32(b[0:4], name)
+		le.PutUint32(b[4:8], uint32(value))
+		le.PutUint32(b[8:12], uint32(size))
+		b[12] = info
+		b[13] = other
+		le.PutUint16(b[14:16], shndx)
+	}
+}
+
 // secDesc is a work-in-progress section header, with link/info kept as names
 // until the final index assignment.
 type secDesc struct {
@@ -215,11 +236,34 @@ type secDesc struct {
 	info     uint32
 	entsize  uint64
 	align    uint64
+	fileData []byte // non-alloc appended section payload (.symtab/.strtab); offset set at emit
+	fileOff  uint64
 }
 
 type loadSeg struct {
 	vaddr, filesz, memsz uint64
 	flags                uint32
+}
+
+// InjectedSym is a caller-supplied symbol (e.g. a recovered JNI function name
+// at a known offset) to write into a real .symtab so IDA/Ghidra show the name.
+type InjectedSym struct {
+	Name  string
+	Value uint64 // offset within the module
+}
+
+// sectionIndexOf returns the index of the allocatable section whose address
+// range contains value, or 0 (SHN_UNDEF) if none does.
+func sectionIndexOf(value uint64, secs []secDesc) uint16 {
+	for i, s := range secs {
+		if s.flags&shfAlloc == 0 || s.size == 0 {
+			continue
+		}
+		if value >= s.addr && value < s.addr+s.size {
+			return uint16(i)
+		}
+	}
+	return 0
 }
 
 // RebuildSoSections takes a memory image of an ELF shared object (ELF32 or
@@ -233,7 +277,7 @@ type loadSeg struct {
 // VERSYM/VERDEF/VERNEED/INIT_ARRAY/FINI_ARRAY give the addresses (and often the
 // sizes) of the corresponding sections. Sections whose size isn't directly
 // known are sized from the next section's start after sorting by address.
-func RebuildSoSections(image []byte) ([]byte, error) {
+func RebuildSoSections(image []byte, injected []InjectedSym) ([]byte, error) {
 	data := make([]byte, len(image))
 	copy(data, image)
 
@@ -569,8 +613,29 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 		}
 	}
 
-	// Reassemble: NULL + sorted allocatable sections + .shstrtab.
+	// Reassemble: NULL + sorted allocatable sections + injected .symtab/.strtab
+	// + .shstrtab.
 	secs = append([]secDesc{secs[0]}, body...)
+
+	// Injected symbols become a real .symtab/.strtab appended at the end of the
+	// file (non-alloc), so tools display caller-supplied names such as recovered
+	// JNI functions. st_shndx points at the rebuilt section containing the value.
+	if len(injected) > 0 {
+		symSz := l.symSize()
+		strtab := []byte{0}
+		symtab := make([]byte, (len(injected)+1)*symSz) // entry 0 is the null symbol
+		for i, s := range injected {
+			nameOff := uint32(len(strtab))
+			strtab = append(strtab, []byte(s.Name)...)
+			strtab = append(strtab, 0)
+			l.putSym(symtab[(i+1)*symSz:], nameOff, s.Value, 0, 0x12, 0, sectionIndexOf(s.Value, secs)) // STB_GLOBAL|STT_FUNC
+		}
+		secs = append(secs,
+			secDesc{name: ".symtab", typ: shtSymtab, entsize: uint64(symSz), align: l.word(), fileData: symtab, linkName: ".strtab", info: 1},
+			secDesc{name: ".strtab", typ: shtStrtab, align: 1, fileData: strtab},
+		)
+	}
+
 	shstrtabIdx := len(secs)
 	secs = append(secs, secDesc{name: ".shstrtab", typ: shtStrtab, align: 1})
 
@@ -604,7 +669,19 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 		remapSymShndx(l, data, int(symAddr), symcount, secs)
 	}
 
-	// Lay out appended data at end of file: [.shstrtab][shdr table].
+	// Lay out appended data at end of file: [non-alloc section payloads]
+	// [.shstrtab][shdr table]. Non-alloc sections (.symtab/.strtab) carry their
+	// bytes in fileData and get their file offset assigned here.
+	for i := range secs {
+		if secs[i].fileData == nil {
+			continue
+		}
+		for secs[i].align > 1 && uint64(len(data))%secs[i].align != 0 {
+			data = append(data, 0)
+		}
+		secs[i].fileOff = uint64(len(data))
+		data = append(data, secs[i].fileData...)
+	}
 	shstrtabOff := uint64(len(data))
 	data = append(data, shstrtab...)
 	for len(data)%int(l.word()) != 0 { // align shdr table to class word size
@@ -621,12 +698,17 @@ func RebuildSoSections(image []byte) ([]byte, error) {
 			shName = nameOff[s.name]
 		}
 		var shOffset, shAddr, shSize uint64 = 0, 0, s.size
-		switch s.name {
-		case "":
+		switch {
+		case s.name == "":
 			// NULL section: all zero
-		case ".shstrtab":
+		case s.name == ".shstrtab":
 			shOffset = shstrtabOff
 			shSize = uint64(len(shstrtab))
+		case s.fileData != nil:
+			// non-alloc appended section (.symtab/.strtab): lives in the file
+			// only, no memory address
+			shOffset = s.fileOff
+			shSize = uint64(len(s.fileData))
 		default:
 			shAddr = s.addr
 			shOffset = s.addr // memory image: offset == addr

--- a/utils.go
+++ b/utils.go
@@ -630,3 +630,39 @@ func FindArtOffsets(libArtPath string, manualExecuteOffset, manualNterpOffset ui
 	}
 	return offsetExecute, offsetExecuteNterp, offsetVerifyClass, nil
 }
+
+// FindRegisterNativesOffset locates art::JNI<>::RegisterNatives in libart by
+// symbol (the mangled name contains 3art, 3JNI and 15RegisterNatives). Returns
+// 0 if it can't be found, in which case JNI name recovery is simply skipped.
+// manualOffset (non-zero) overrides auto-detection.
+func FindRegisterNativesOffset(libArtPath string, manualOffset uint64) uint64 {
+	if manualOffset != 0 {
+		return manualOffset
+	}
+	f, err := elf.Open(libArtPath)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	scan := func(syms []elf.Symbol) uint64 {
+		for _, sym := range syms {
+			n := sym.Name
+			if strings.Contains(n, "3art") && strings.Contains(n, "3JNI") && strings.Contains(n, "15RegisterNatives") {
+				return sym.Value
+			}
+		}
+		return 0
+	}
+	if syms, err := f.Symbols(); err == nil {
+		if v := scan(syms); v != 0 {
+			return v
+		}
+	}
+	if dyn, err := f.DynamicSymbols(); err == nil {
+		if v := scan(dyn); v != 0 {
+			return v
+		}
+	}
+	return 0
+}

--- a/utils.go
+++ b/utils.go
@@ -635,6 +635,13 @@ func FindArtOffsets(libArtPath string, manualExecuteOffset, manualNterpOffset ui
 // symbol (the mangled name contains 3art, 3JNI and 15RegisterNatives). Returns
 // 0 if it can't be found, in which case JNI name recovery is simply skipped.
 // manualOffset (non-zero) overrides auto-detection.
+//
+// Modern ART defines the JNI entrypoints as template<bool kEnableIndexIds>
+// class JNI, so *two* symbols match the pattern: art::JNI<false> (mangled
+// ...3JNIILb0EE..., the table the runtime dispatches to by default) and
+// art::JNI<true> (...3JNIILb1EE..., the CheckJNI variant). Attaching to the
+// <true> one captures nothing under the default config, so prefer the <false>
+// (Lb0E) instantiation and only fall back to any match if it isn't present.
 func FindRegisterNativesOffset(libArtPath string, manualOffset uint64) uint64 {
 	if manualOffset != 0 {
 		return manualOffset
@@ -646,13 +653,21 @@ func FindRegisterNativesOffset(libArtPath string, manualOffset uint64) uint64 {
 	defer f.Close()
 
 	scan := func(syms []elf.Symbol) uint64 {
+		var fallback uint64
 		for _, sym := range syms {
 			n := sym.Name
-			if strings.Contains(n, "3art") && strings.Contains(n, "3JNI") && strings.Contains(n, "15RegisterNatives") {
+			if !strings.Contains(n, "3art") || !strings.Contains(n, "3JNI") || !strings.Contains(n, "15RegisterNatives") {
+				continue
+			}
+			// art::JNI<false> — the instantiation the runtime actually calls.
+			if strings.Contains(n, "Lb0E") {
 				return sym.Value
 			}
+			if fallback == 0 {
+				fallback = sym.Value
+			}
 		}
-		return 0
+		return fallback
 	}
 	if syms, err := f.Symbols(); err == nil {
 		if v := scan(syms); v != 0 {


### PR DESCRIPTION
Extends the existing DEX-focused dumper with native-layer support: dumpso scans a target process's /proc/<pid>/maps, merges each library's separately mapped segments (r--/r-x/rw-) back into one contiguous span, and reads it out via process_vm_readv - reusing the same technique the dex-fallback path already relies on, but as the primary mechanism here (no eBPF/uprobes involved). It also optionally scans anonymous, path-less memory regions whose first page starts with the ELF magic, to catch libraries a packer mapped/decrypted itself instead of going through the dynamic linker.

fixso rewrites each dumped PT_LOAD segment's p_offset to match p_vaddr and raises p_filesz to p_memsz, then clears the stale e_shoff/e_shnum/e_shstrndx fields (the section header table was never part of the memory image), so IDA/Ghidra/objdump can load the result directly. dumpso runs it automatically after dumping unless --no-auto-fix is passed, mirroring dump/fix.

Validated with a native amd64 build (build tags stripped) against the full existing package, plus a live self-dump/fix/readelf round-trip on this host's own libc/ld-linux, since no arm64/NDK cross toolchain is available in this environment to build+run the real target directly. That live run surfaced a real cgo issue - passing a remote address as unsafe.Pointer(uintptr(addr)) can panic if Go's cgocheck mistakes the bit pattern for a pointer into this process's own heap - fixed by typing the C helper's address parameter as uintptr_t instead of void*, scoped to the new code path only.